### PR TITLE
Add unit testing module

### DIFF
--- a/inc/test.h
+++ b/inc/test.h
@@ -1,0 +1,243 @@
+/******************************************************************************
+ *                           SOL LIBRARY v0.1.0+41
+ *
+ * File: sol/inc/test.h
+ *
+ * Description:
+ *      This file is part of the API of the Sol Library. It declares the
+ *      interface of the unit testing module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+#if !defined __SOL_UNIT_TESTING_MODULE
+#define __SOL_UNIT_TESTING_MODULE
+
+
+
+
+/*
+ *      SOL_ERNO_TEST - unit testing module error
+ *
+ *      The SOL_ERNO_TEST error code indicates that an error has occured with
+ *      the unit testing module while calling one of its interface functions.
+ *      Note the this error code is **not** used to indicate a unit test that
+ *      has failed, as it would have been successfully executed as far as the
+ *      module interface is concerned.
+ */
+#define SOL_ERNO_TEST -1
+
+
+
+
+/*
+ *      sol_test_unit - unit test callback
+ *
+ *      The sol_test_unit callback function defines the unit test that is to be
+ *      executed by the unit testing module of the Sol Library. The unit test
+ *      callback is defined by the client code, and executed through the
+ *      sol_test_exec() function declared below.
+ *
+ *      The unit test callback is expected to return an error code indicating
+ *      whether or not the test passed. The callback must return a non-zero
+ *      error code (except those reserved by the Sol Library) to indicate that
+ *      the unit test has failed.
+ *
+ *      Return:
+ *        - 0 if the unit test passes
+ *        - Non-zero if the unit test fails
+ */
+typedef int
+(sol_test_unit)(void);
+
+
+
+
+/*
+ *      sol_test_log - test logging callback
+ *        - desc: unit test description
+ *        - erno: error code returned by unit test
+ *
+ *      The sol_test_log callback function defines the logging mechanism that is
+ *      to be used by the unit testing module to log the results of the unit
+ *      tests executed through sol_test_exec().
+ *
+ *      The sol_test_log callback is defined by client code, and plugged in to
+ *      the unit testing module through the sol_test_init2() function. If this
+ *      callback function is available to the unit testing module, it will be
+ *      passed the description @desc of the unit test, and the error code @erno
+ *      returned by the unit test.
+ */
+typedef void
+(sol_test_log)(char const *desc,
+               int  const erno
+              );
+
+
+
+
+/*
+ *      sol_test_init() - sets up unit testing module
+ *
+ *      The sol_test_init() interface function initialises the unit testing
+ *      module to its default state. This function **must** be called before
+ *      calling any of the other interface functions of this module, other than
+ *      the overloaded sol_test_init2() function.
+ *
+ *      This function initialises the unit testing module without hooking up a
+ *      logging callback function, and so is suitable for use in freestanding
+ *      environments, or in situations where logging of the unit tests is not
+ *      required. If logging of the unit test results is required, then the
+ *      overloaded version sol_test_init2() should be used instead.
+ *
+ *      Return:
+ *        - 0 if no error occurs
+ *        - SOL_ERNO_TEST if an error occurs
+ */
+extern int
+sol_test_init(void);
+
+
+
+
+/*
+ *      sol_test_init2() - sets up unit testing module
+ *        - path: path to log file
+ *        - cbk : logging callback
+ *
+ *      The sol_test_init2() interface function is the overloaded form of the
+ *      sol_test_init() function declared above. This function, like its
+ *      original form, initialises the unit testing module, but additionally
+ *      hooks up a callback function @cbk that is used to log the unit test
+ *      results to a file at a given location @path.
+ *
+ *      Both @path and @cbk are required to be valid pointers, and @path is
+ *      additionally required to be a non-null string. However, if these
+ *      conditions are not met, then a safe no-op occurs.
+ *
+ *      Return:
+ *        - 0 if no error occurs
+ *        - SOL_ERNO_TEST if an error occurs
+ */
+extern int
+sol_test_init2(char         const *path,
+               sol_test_log const *cbk
+              );
+
+
+
+
+/*
+ *      sol_test_exit() - tears down unit testing module
+ *
+ *      The sol_test_exit() interface function winds up the unit testing module.
+ *      This function is expected to be called once all unit tests have been
+ *      completed and the unit testing module is no longer required by client
+ *      code.
+ */
+extern void
+sol_test_exit(void);
+
+
+
+
+/*
+ *      sol_test_pass() - gets passed unit test count
+ *        - pass: count of passed unit tests
+ *
+ *      The sol_test_pass() interface function returns the number of unit tests
+ *      that have been successfully executed through the sol_test_exec()
+ *      interface function.
+ *
+ *      The count of successful unit tests is returned through @pass, which is
+ *      required to be a valid pointer. Furthermore, the unit testing module
+ *      must have been first initialised by a call to either sol_test_init() or
+ *      sol_test_init2().
+ *
+ *      Return:
+ *        - 0 if no error occurs
+ *        - SOL_ERNO_TEST if an error occurs
+ */
+extern int
+sol_test_pass(int *pass);
+
+
+
+
+/*
+ *      sol_test_fail() - gets failed unit test count
+ *        - fail: count of failed unit tests
+ *
+ *      The sol_test_fail() interface function returns the number of unit tests
+ *      that have **not** been successfully executed through the sol_test_exec()
+ *      interface function.
+ *
+ *      The count of unsuccessful unit tests is returned through @fail, which is
+ *      expected to be a valid pointer. Furthermore, the unit testing module
+ *      must have been first initialised by a call to either sol_test_init() or
+ *      sol_test_init2().
+ *
+ *      Return:
+ *        - 0 if no error occurs
+ *        - SOL_ERNO_TEST if an error occurs
+ */
+extern int
+sol_test_fail(int *fail);
+
+
+
+
+/*
+ *      sol_test_exec() - executes unit test
+ *        - desc: unit test description
+ *        - cbk : unit test callback
+ *
+ *      The sol_test_exec() function executes a unit test defined by client code
+ *      through a callback function @cbk with a given description @desc. If the
+ *      unit testing module has been initialised with a logging callback through
+ *      sol_test_init2(), then this function also logs the result of the unit
+ *      test defined by @cbk.
+ *
+ *      Both @desc and @cbk are required to be valid pointers; additionally,
+ *      @desc is required to be a non-null string. If either of these conditions
+ *      is not met, then an exception is thrown.
+ *
+ *      Return:
+ *        - 0 if the unit test passes
+ *        - SOL_ERNO_TEST if an error occurs on executing the unit test
+ *        - An contextual error code if the unit test fails
+ */
+extern int
+sol_test_exec(char          const *desc,
+              sol_test_unit const *cbk
+             );
+
+
+
+
+#endif /* !defined __SOL_UNIT_TESTING_MODULE  */
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/src/test.c
+++ b/src/test.c
@@ -1,0 +1,319 @@
+/******************************************************************************
+ *                           SOL LIBRARY v1.0.0+41
+ *
+ * File: sol/src/test.c
+ *
+ * Description:
+ *      This file is part of the internal implementation of the Sol Library.
+ *      It implements the unit testing module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+/*
+ *      Include required header files.
+ */
+#include "../inc/test.h"
+
+
+
+
+/*
+ *      mod_init - module intialisation flag
+ *
+ *      The mod_init global variable keeps track whether or not the unit testing
+ *      module has been initialised by a call to either the sol_test_init() or
+ *      sol_test_init2() interface functions.
+ *
+ *      Although this flag is not strictly required, it helps to improve best
+ *      practices by ensuring that the module is first initialised before it is
+ *      used by client code.
+ *
+ *      The initial value of of mod_init defaults to 0 to indicate that the unit
+ *      testing module has not been initialised. On the contrary, a value of 1
+ *      indicates that the unit testing module has been initialised.
+ */
+static int mod_init = 0;
+
+
+
+
+/*
+ *      unit_pass - passed unit test counter
+ *
+ *      The unit_pass global variable keeps track of the number of unit tests
+ *      that have been successfully executed. It is initialised to zero since no
+ *      unit tests have been executed on initalisation of the unit testing
+ *      module. This variable is related to the unit_fail global declared below.
+ */
+static int unit_pass = 0;
+
+
+
+
+/*
+ *      unit_fail - failed unit test counter
+ *
+ *      The unit_fail global variable, similar to the unit_pass global declared
+ *      above, keeps track of the the number of unit tests that did **not**
+ *      pass. It is also initialised to zero as no unit tests have been executed
+ *      at the time of initialising the unit testing module.
+ */
+static int unit_fail = 0;
+
+
+
+
+/*
+ *      LOG_MAXPATHLEN - maximum length of log path
+ *
+ *      The LOG_MAXPATHLEN symbolic constant defines the maximum number of
+ *      characters that are assumed to be in the log file path. I think it's
+ *      safe to assume that a maximum length of 256 characters should be more
+ *      than adequate for all use cases.
+ */
+#define LOG_MAXPATHLEN 256
+
+
+
+
+/*
+ *      log_path - path to log file
+ *
+ *      The log_path global variable is a buffer to hold the path to the file
+ *      which will be used to log the results of the executed unit tests. The
+ *      length of the log_path variable is set to the LOG_MAXPATHLEN symbolic
+ *      constant defined above.
+ */
+static char log_path [LOG_MAXPATHLEN];
+
+
+
+
+/*
+ *      log_cbk - logging callback
+ *
+ *      The log_cbk global variable points to the callback function used to log
+ *      the test results for each unit test that is executed.
+ */
+static sol_test_log *log_cbk;
+
+
+
+
+/*
+ *      unit_init() - initialises unit test globals
+ *
+ *      The unit_init() utility function initialises the the unit test globals
+ *      to their default value of zero. When the unit testing module is started,
+ *      no unit tests have been executed, so it makes sense to set the test
+ *      counters to zero.
+ */
+static inline void
+unit_init(void)
+{
+        unit_pass = 0;
+        unit_fail = 0;
+}
+
+
+
+
+/*
+ *      log_init() - initialises logging globals
+ *        - path: path to log file
+ *        - cbk : logging callback
+ *
+ *      The log_init() utility function initialises the logging global
+ *      variables. It does so by assigning these variables the arguments passed
+ *      through its parameters @path and @cbk. @path is copied on to the log
+ *      file path global using the standard strncpy() algorithm. I'm not calling
+ *      strncpy() directly as I would have to include the standard <string.h>
+ *      header file which isn't available in freestanding environments.
+ *
+ *      This function assumes that both @path and @cbk are valid, leaving it up
+ *      to the calling function to ensure that this is so.
+ */
+static inline void
+log_init(char         const *path,
+         sol_test_log const *cbk
+        )
+{
+        register char *itr = log_path;
+        auto     int  len  = LOG_MAXPATHLEN;
+
+        log_cbk = cbk;
+
+        while (len-- && (*itr++ = *path++));
+}
+
+
+
+
+/*
+ *      sol_test_init() - declared in sol/inc/test.h
+ *
+ *      The sol_test_init() interface function needs only to initialise the unit
+ *      test counters; it does so by calling the unit_init() utility function.
+ *      It also sets the mod_init flag to 1 to indicate that unit testing module
+ *      has been intialised.
+ *
+ *      The sol_test_init() function can't fail, so it always returns 0 to
+ *      indicate that no error has occured.
+ */
+extern int
+sol_test_init(void)
+{
+        unit_init ();
+        mod_init = 1;
+
+        return 0;
+}
+
+
+
+
+/*
+ *      sol_test_init2() - declared in sol/inc/test.h
+ *
+ *      The sol_test_init2() interface function needs to initialise both the
+ *      unit test counters and the logging global variables through the
+ *      unit_init() and log_init() utility functions respectively. The logging
+ *      variables are initialised only if the arguments to the parameters @path
+ *      and @cbk are valid. Once initialisation is complete, the mod_init flag
+ *      is set to 1 to indicate that the unit testing module has been set up.
+ */
+extern int
+sol_test_init2(char         const *path,
+               sol_test_log const *cbk
+              )
+{
+        if (!(cbk && path && *path))
+                return SOL_ERNO_TEST;
+
+        unit_init ();
+        log_init (path, cbk);
+        mod_init = 1;
+
+        return 0;
+}
+
+
+
+
+/*
+ *      sol_test_exit() - declared in sol/inc/test.h
+ *
+ *      The sol_test_exit() interface function resets the unit test counters to
+ *      their default value, and sets the internal module initialisation flag to
+ *      0 to indicate that unit testing module has been torn down.
+ *
+ *      This isn't  strictly necessary, but doing so keeps the internal state of
+ *      the unit  testing module clean, and ensures that the other interface
+ *      functions can't be called without first re-initialising the module.
+ */
+extern void
+sol_test_exit(void)
+{
+        unit_init ();
+        mod_init = 0;
+}
+
+
+
+
+/*
+ *      sol_test_pass() - declared in sol/inc/test.h
+ *
+ *      The sol_test_pass() interface function returns the unit test pass
+ *      counter through @pass after checking whether the unit testing module has
+ *      been initialised and if @pass is valid.
+ */
+extern int
+sol_test_pass(int *pass)
+{
+        if (!(mod_init && pass))
+                return SOL_ERNO_TEST;
+
+        *pass = unit_pass;
+        return 0;
+}
+
+
+
+
+/*
+ *      sol_test_fail() - declared in sol/inc/test.h
+ *
+ *      The sol_test_fail() interface function returns the unit test fail
+ *      counter through @fail after checking whether the unit testing module has
+ *      been initialised and if @fail is valid.
+ */
+extern int
+sol_test_fail(int *fail)
+{
+        if (!(mod_init && fail))
+                return SOL_ERNO_TEST;
+
+        *fail = unit_fail;
+        return 0;
+}
+
+
+
+
+/*
+ *      sol_test_exec() - declared in sol/inc/test.h
+ *
+ *      The sol_test_exec() interface function runs the unit test @cbk, updating
+ *      the appropriate test counter depending on whether @cbk passed or failed.
+ *      Furthermore, the test result is logged by calling the logging callback
+ *      function (if it's available). At the outset, this function checks  if
+ *      the unit testing module has been intialised, and whether the arguments
+ *      for @desc and @cbk are valid.
+ */
+extern int
+sol_test_exec(char          const *desc,
+              sol_test_unit const *cbk
+             )
+{
+        auto int erno;
+
+        if (!(mod_init && cbk && desc && *desc))
+                return SOL_ERNO_TEST;
+
+        if ((erno = cbk ()))
+                unit_fail ++;
+        else
+                unit_pass ++;
+
+        if (log_cbk)
+                log_cbk (desc, erno);
+
+        return erno;
+}
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+


### PR DESCRIPTION
The unit testing module has been implemented with the following
interface functions:
  * sol_test_init()
  * sol_test_init2()
  * sol_test_exit()
  * sol_test_pass()
  * sol_test_fail()
  * sol_test_exec()

Testing for this module has been deferred until the implementation of
another module which can be used as the guinea pig for checking whether
the testing module is working correctly.

This pull request closes #5 