### PR TITLE
Provision for thread safety in unit testing module

### DIFF
--- a/inc/error.h
+++ b/inc/error.h
@@ -69,6 +69,47 @@ typedef size_t sol_erno;
 
 
 /*
+ *      SOL_ERNO_PTR - invalid pointer
+ *
+ *      The SOL_ERNO_PTR symbolic constant indicates that an invalid pointer has
+ *      been passed to an interface function or macro. This error code is
+ *      reserved by the Sol Library, and should **not** be redefined by client
+ *      code.
+ */
+#define SOL_ERNO_PTR ((sol_erno) 0x1)
+
+
+
+
+/*
+ *      SOL_ERNO_STR - invalid string
+ *
+ *      The SOL_ERNO_STR symbolic constant indicates that an invalid string has
+ *      been passed to an interface function or macro. An invalid string is not
+ *      necessarily a null string, and will depend on the context. Note that
+ *      this error code should not be used to indicate null string pointers, and
+ *      should be indicated by SOL_ERNO_PTR instead. This error code is reserved
+ *      by the Sol Library, and should **not** be redefined by client code.
+ */
+#define SOL_ERNO_STR ((sol_erno) 0x2)
+
+
+
+
+/*
+ *      SOL_ERNO_RANGE - range error
+ *
+ *      The SOL_ERNO_RANGE symbolic constant indicates that a value that is
+ *      outside its acceptable range has been passed to an interface function or
+ *      macro. This error code is reserved by the Sol Library, and should
+ *      **not** be redefined by client code.
+ */
+#define SOL_ERNO_RANGE ((sol_erno) 0x3)
+
+
+
+
+/*
  *      SOL_TRY - start of try block
  *
  *      The SOL_TRY label identifies the starting point of the try block within
@@ -88,6 +129,7 @@ typedef size_t sol_erno;
  */
 #define SOL_TRY                                       \
         register sol_erno __sol_erno = SOL_ERNO_NULL; \
+        goto __SOL_TRY;                               \
         __SOL_TRY
 
 
@@ -167,7 +209,7 @@ typedef size_t sol_erno;
         do {                                       \
                 if (!(p)) {                        \
                         __sol_erno = (e);          \
-                        goto __SOL_CATCH:          \
+                        goto __SOL_CATCH;          \
                 }                                  \
         } while (0)
 

--- a/inc/test.h
+++ b/inc/test.h
@@ -32,201 +32,292 @@
 
 
 
+#include "./error.h"
+
+
+
+
 /*
- *      SOL_ERNO_TEST - unit testing module error
+ *      SOL_TSUITE_MAXTCASE - maximum number of test cases in a test suite
  *
- *      The SOL_ERNO_TEST error code indicates that an error has occured with
- *      the unit testing module while calling one of its interface functions.
- *      Note the this error code is **not** used to indicate a unit test that
- *      has failed, as it would have been successfully executed as far as the
- *      module interface is concerned.
+ *      The SOL_TSUITE_MAXTCASE symbolic constant defines the maxiumum number of
+ *      test cases that can be registered in one test suite. The cap limit of
+ *      128 test cases is expected to be more than adequate for most situations.
  */
-#define SOL_ERNO_TEST -1
+#define SOL_TSUITE_MAXTCASE 128
 
 
 
 
 /*
- *      sol_test_unit - unit test callback
+ *      SOL_TCASE_MAXDESCLEN - maximum length of test case description
  *
- *      The sol_test_unit callback function defines the unit test that is to be
- *      executed by the unit testing module of the Sol Library. The unit test
- *      callback is defined by the client code, and executed through the
- *      sol_test_exec() function declared below.
+ *      The SOL_TCASE_MAXDESCLEN symbolic constant defines the maximum length of
+ *      the description for a test case. The limit of 128 characters (including
+ *      the terminating null character) should be adequate for most situations.
+ */
+#define SOL_TCASE_MAXDESCLEN 128
+
+
+
+
+/*
+ *      sol_tcase - test case callback
  *
- *      The unit test callback is expected to return an error code indicating
- *      whether or not the test passed. The callback must return a non-zero
- *      error code (except those reserved by the Sol Library) to indicate that
- *      the unit test has failed.
+ *      The sol_tcase callback function defines a test case that may be executed
+ *      as part of a test suite abstracted by the sol_tsuite type defined below.
+ *      The test case callback is defined by client code, and needs to be
+ *      registered with a test suite through the sol_tsuite_register() function
+ *      in order to be executed. The test case callback is required to return an
+ *      error code indicating whether or not it passed.
  *
  *      Return:
- *        - 0 if the unit test passes
- *        - Non-zero if the unit test fails
+ *        - SOL_ERNO_NULL if the test case passes
+ *        - A context-sensitive error code if the test case fails
  */
-typedef int
-(sol_test_unit)(void);
+typedef sol_erno
+(sol_tcase)(void);
 
 
 
 
 /*
- *      sol_test_log - test logging callback
+ *      sol_tlog - test suite logging callback
  *        - desc: unit test description
- *        - erno: error code returned by unit test
+ *        - erno: error code returned by a test case
  *
- *      The sol_test_log callback function defines the logging mechanism that is
- *      to be used by the unit testing module to log the results of the unit
- *      tests executed through sol_test_exec().
+ *      The sol_tlog callback function defines the logging mechanism that is to
+ *      be used by a sol_tsuite test suite to log the results of its registered
+ *      test cases when they are executed through sol_tsuite_exec().
  *
- *      The sol_test_log callback is defined by client code, and plugged in to
- *      the unit testing module through the sol_test_init2() function. If this
- *      callback function is available to the unit testing module, it will be
- *      passed the description @desc of the unit test, and the error code @erno
- *      returned by the unit test.
+ *      The sol_tlog callback is defined by client code, and plugged into a test
+ *      suite through the sol_tsuite_init2() function. If this callback function
+ *      is available to a test suite, it will be passed the description @desc of
+ *      each test case executed, along with the error code @erno returned by the
+ *      test case.
  */
 typedef void
-(sol_test_log)(char const *desc,
-               int  const erno
-              );
+(sol_tlog)(char     const *desc,
+           sol_erno const erno
+          );
 
 
 
 
 /*
- *      sol_test_init() - sets up unit testing module
+ *      sol_tsuite - test suite
  *
- *      The sol_test_init() interface function initialises the unit testing
- *      module to its default state. This function **must** be called before
- *      calling any of the other interface functions of this module, other than
- *      the overloaded sol_test_init2() function.
+ *      The sol_tsuite type abstracts a test suite. A test suite is a collection
+ *      of related test cases, each of which is defined by a sol_tcase callback
+ *      function.
  *
- *      This function initialises the unit testing module without hooking up a
- *      logging callback function, and so is suitable for use in freestanding
- *      environments, or in situations where logging of the unit tests is not
- *      required. If logging of the unit test results is required, then the
- *      overloaded version sol_test_init2() should be used instead.
+ *      Although the sol_tsuite type is defined as a transparent type so that it
+ *      has no dependence on heap memory interfaces (which may not be available
+ *      in freestanding environments), it should be treated as an opaque type,
+ *      and unsed only through its interface functions declared below.
+ */
+typedef struct __sol_tsuite {
+        int       total;
+        int       fail;
+        char      desc   [SOL_TSUITE_MAXTCASE] [SOL_TCASE_MAXDESCLEN];
+        sol_tcase *tcase [SOL_TSUITE_MAXTCASE];
+        sol_tlog  *tlog;
+} sol_tsuite;
+
+
+
+
+/*
+ *      sol_tsuite_init() - initialises test suite
+ *        - tsuite: contextual test suite
+ *
+ *      The sol_tsuite_init() interface function initialises a test suite
+ *      @tsuite to its default state. This function **must** be called before
+ *      calling any of the other interface functions of sol_tsuite, other than
+ *      the overloaded sol_tsuite_init2() function.
+ *
+ *      This function initialises @tsuite without hooking up a logging callback
+ *      function, and so is suitable for use in freestanding environments, or in
+ *      situations where logging of the unit tests is not required. If logging
+ *      of the test cases is required, then the overloaded version
+ *      sol_tsuite_init2() should be used instead.
  *
  *      Return:
- *        - 0 if no error occurs
- *        - SOL_ERNO_TEST if an error occurs
+ *        - SOL_ERNO_NULL if no error occurs
+ *        - SOL_ERNO_PTR if an invalid pointer is passed
  */
-extern int
-sol_test_init(void);
+extern sol_erno
+sol_tsuite_init(sol_tsuite *tsuite);
 
 
 
 
 /*
- *      sol_test_init2() - sets up unit testing module
- *        - path: path to log file
- *        - cbk : logging callback
+ *      sol_tsuite_init2() - initialises test suite
+ *        - tsuite: contextual test suite
+ *        - tlog  : test logging callback
  *
- *      The sol_test_init2() interface function is the overloaded form of the
- *      sol_test_init() function declared above. This function, like its
- *      original form, initialises the unit testing module, but additionally
- *      hooks up a callback function @cbk that is used to log the unit test
- *      results to a file at a given location @path.
+ *     The sol_tsuite_init2() interface function is the overloaded form of the
+ *     sol_tsuite_init() function declared above. This function, like its
+ *     original form, intialises a test suite instance @tsuite, but additionally
+ *     hooks up a callback function @tlog that is used to log the test case
+ *     results. This function **must** be called before any of the other
+ *     sol_tsuite interface functions are invoked on @tsuite, apart from
+ *     sol_tsuite_init().
  *
- *      Both @path and @cbk are required to be valid pointers, and @path is
- *      additionally required to be a non-null string. However, if these
- *      conditions are not met, then a safe no-op occurs.
+ *     Both @tsuite and @tlog are required to be valid pointers; otherwise, an
+ *     exception is thrown.
  *
- *      Return:
- *        - 0 if no error occurs
- *        - SOL_ERNO_TEST if an error occurs
+ *     Return:
+ *       - SOL_ERNO_NULL if no error occurs
+ *       - SOL_ERNO_PTR if an invalid pointer is passed as an argument
  */
-extern int
-sol_test_init2(char         const *path,
-               sol_test_log const *cbk
-              );
+extern sol_erno
+sol_tsuite_init2(sol_tsuite        *tsuite,
+                 sol_tlog    const *tlog
+                );
 
 
 
 
 /*
- *      sol_test_exit() - tears down unit testing module
+ *      sol_tsuite_term() - terminates a test suite
+ *        - tsuite: contextual test suite
  *
- *      The sol_test_exit() interface function winds up the unit testing module.
- *      This function is expected to be called once all unit tests have been
- *      completed and the unit testing module is no longer required by client
- *      code.
+ *      The sol_tsuite_term() interface function terminates a test suite
+ *      instance @tsuite that was earlier initialised by a call to either
+ *      sol_tsuite_init() or sol_tsuite_init2(). Although this function expects
+ *      @tsuite to be a valid pointer, a safe no-op occurs if this condition is
+ *      not satisfied.
  */
 extern void
-sol_test_exit(void);
+sol_tsuite_term(sol_tsuite *tsuite);
 
 
 
 
 /*
- *      sol_test_pass() - gets passed unit test count
- *        - pass: count of passed unit tests
+ *      sol_tsuite_register() - registers a test case
+ *        - tsuite: contextual test suite
+ *        - tcase : test case to register
+ *        - desc  : test case description
  *
- *      The sol_test_pass() interface function returns the number of unit tests
- *      that have been successfully executed through the sol_test_exec()
- *      interface function.
+ *     The sol_tsuite_register() interface function registers a test case @tcase
+ *     described by @desc with a test suite @tsuite. A test case must first be
+ *     registered as part of a test suite before it can be executed. This
+ *     function allows a maximum of SOL_TSUITE_MAXTCASE test cases to be
+ *     registered with @tsuite, and automatically truncates the length of @desc
+ *     to SOL_TCASE_MAXDESCLEN characters if required.
  *
- *      The count of successful unit tests is returned through @pass, which is
- *      required to be a valid pointer. Furthermore, the unit testing module
- *      must have been first initialised by a call to either sol_test_init() or
- *      sol_test_init2().
+ *     @tsuite, @tcase, and @desc must all be valid pointers, and additionally
+ *     @desc must be a non-null string; if any of these conditions is not met,
+ *     then an exception is thrown.
  *
- *      Return:
- *        - 0 if no error occurs
- *        - SOL_ERNO_TEST if an error occurs
+ *     Return:
+ *       - SOL_ERNO_NULL if no error occurs
+ *       - SOL_ERNO_PTR if an invalid pointer is passed as an argument
+ *       - SOL_ERNO_STR if @desc is a null string
+ *       - SOL_ERNO_RANGE if the limit of registered test cases is exceeded
  */
-extern int
-sol_test_pass(int *pass);
+extern sol_erno
+sol_tsuite_register(sol_tsuite       *tsuite,
+                    sol_tcase  const *tcase,
+                    char       const *desc
+                   );
 
 
 
 
 /*
- *      sol_test_fail() - gets failed unit test count
- *        - fail: count of failed unit tests
+ *      sol_tsuite_pass() - count of passed test cases
+ *        - tsuite: contextual test suite
+ *        - pass  : count of passed test cases
  *
- *      The sol_test_fail() interface function returns the number of unit tests
- *      that have **not** been successfully executed through the sol_test_exec()
- *      interface function.
+ *      The sol_tsuite_pass() interface function returns the number of test
+ *      cases @pass of a test suite @tsuite that have been successfully run
+ *      through the sol_tsuite_exec() interface function.
  *
- *      The count of unsuccessful unit tests is returned through @fail, which is
- *      expected to be a valid pointer. Furthermore, the unit testing module
- *      must have been first initialised by a call to either sol_test_init() or
- *      sol_test_init2().
+ *      Both @tsuite and @pass are required to be valid pointers, or else an
+ *      exception is thrown.
  *
  *      Return:
- *        - 0 if no error occurs
- *        - SOL_ERNO_TEST if an error occurs
+ *        - SOL_ERNO_NULL if no error occurs
+ *        - SOL_ERNO_PTR if an invalid pointer is passed as an argument
  */
-extern int
-sol_test_fail(int *fail);
+extern sol_erno
+sol_tsuite_pass(sol_tsuite const *tsuite,
+                int              *pass
+               );
 
 
 
 
 /*
- *      sol_test_exec() - executes unit test
- *        - desc: unit test description
- *        - cbk : unit test callback
+ *      sol_tsuite_fail() - count of failed test cases
+ *        - tsuite: contextual test suite
+ *        - fail  : count of failed test cases
  *
- *      The sol_test_exec() function executes a unit test defined by client code
- *      through a callback function @cbk with a given description @desc. If the
- *      unit testing module has been initialised with a logging callback through
- *      sol_test_init2(), then this function also logs the result of the unit
- *      test defined by @cbk.
+ *      The sol_tsuite_fail() interface function returns the number of test
+ *      cases @fail of a test suite @tsuite that have failed when executed
+ *      through the sol_tsuite_exec() interface function.
  *
- *      Both @desc and @cbk are required to be valid pointers; additionally,
- *      @desc is required to be a non-null string. If either of these conditions
- *      is not met, then an exception is thrown.
+ *      Both @tsuite @fail are required to be valid pointers, or else an
+ *      exception is thrown.
  *
  *      Return:
- *        - 0 if the unit test passes
- *        - SOL_ERNO_TEST if an error occurs on executing the unit test
- *        - An contextual error code if the unit test fails
+ *        - SOL_ERNO_NULL if no error occurs
+ *        - SOL_ERNO_PTR if an invalid pointer is passed as an argument
  */
-extern int
-sol_test_exec(char          const *desc,
-              sol_test_unit const *cbk
-             );
+extern sol_erno
+sol_tsuite_fail(sol_tsuite const *tsuite,
+                int              *fail
+               );
+
+
+
+
+/*
+ *      sol_tsuite_total() - count of total test cases
+ *        - tsuite: contextual test suite
+ *        - total : count of total test cases
+ *
+ *      The sol_tsuite_total() interface function returns the total number of
+ *      test cases @total registered with a test suite @tsuite.
+ *
+ *      Both @tsuite and @total are required to be valid pointers, or else an
+ *      exception is thrown.
+ *
+ *      Return:
+ *        - SOL_ERNO_NULL if no error occurs
+ *        - SOL_ERNO_PTR if an invalid pointer is passed as an argument
+ */
+extern sol_erno
+sol_tsuite_total(sol_tsuite const *tsuite,
+                 int              *total
+                );
+
+
+
+
+/*
+ *      sol_tsuite_exec() - executes registered test cases
+ *        - tsuite: contextual test suite
+ *
+ *      The sol_tsuite_exec() interface function sequentially executes all the
+ *      test cases registered with a test suite @tsuite. If @tsuite had been
+ *      hooked to a logging callback at the time of initialisation through
+ *      sol_tsuite_init2(), then this function also logs the result of each test
+ *      case executed.
+ *
+ *      @tsuite is required to be a valid pointer, or else an exception is
+ *      thrown.
+ *
+ *      Return:
+ *        - SOL_ERNO_NULL if no error occurs
+ *        - SOL_ERNO_PTR if an invalid argument is passed
+ */
+extern sol_erno
+sol_tsuite_exec(sol_tsuite *tsuite);
 
 
 

--- a/src/test.c
+++ b/src/test.c
@@ -35,278 +35,231 @@
 
 
 /*
- *      mod_init - module intialisation flag
- *
- *      The mod_init global variable keeps track whether or not the unit testing
- *      module has been initialised by a call to either the sol_test_init() or
- *      sol_test_init2() interface functions.
- *
- *      Although this flag is not strictly required, it helps to improve best
- *      practices by ensuring that the module is first initialised before it is
- *      used by client code.
- *
- *      The initial value of of mod_init defaults to 0 to indicate that the unit
- *      testing module has not been initialised. On the contrary, a value of 1
- *      indicates that the unit testing module has been initialised.
+ *      tsuite_init() - initialises test suite member fields
  */
-static int mod_init = 0;
-
-
-
-
-/*
- *      unit_pass - passed unit test counter
- *
- *      The unit_pass global variable keeps track of the number of unit tests
- *      that have been successfully executed. It is initialised to zero since no
- *      unit tests have been executed on initalisation of the unit testing
- *      module. This variable is related to the unit_fail global declared below.
- */
-static int unit_pass = 0;
-
-
-
-
-/*
- *      unit_fail - failed unit test counter
- *
- *      The unit_fail global variable, similar to the unit_pass global declared
- *      above, keeps track of the the number of unit tests that did **not**
- *      pass. It is also initialised to zero as no unit tests have been executed
- *      at the time of initialising the unit testing module.
- */
-static int unit_fail = 0;
-
-
-
-
-/*
- *      LOG_MAXPATHLEN - maximum length of log path
- *
- *      The LOG_MAXPATHLEN symbolic constant defines the maximum number of
- *      characters that are assumed to be in the log file path. I think it's
- *      safe to assume that a maximum length of 256 characters should be more
- *      than adequate for all use cases.
- */
-#define LOG_MAXPATHLEN 256
-
-
-
-
-/*
- *      log_path - path to log file
- *
- *      The log_path global variable is a buffer to hold the path to the file
- *      which will be used to log the results of the executed unit tests. The
- *      length of the log_path variable is set to the LOG_MAXPATHLEN symbolic
- *      constant defined above.
- */
-static char log_path [LOG_MAXPATHLEN];
-
-
-
-
-/*
- *      log_cbk - logging callback
- *
- *      The log_cbk global variable points to the callback function used to log
- *      the test results for each unit test that is executed.
- */
-static sol_test_log *log_cbk;
-
-
-
-
-/*
- *      unit_init() - initialises unit test globals
- *
- *      The unit_init() utility function initialises the the unit test globals
- *      to their default value of zero. When the unit testing module is started,
- *      no unit tests have been executed, so it makes sense to set the test
- *      counters to zero.
- */
-static inline void
-unit_init(void)
+static void
+tsuite_init(sol_tsuite       *tsuite, /* contextual test suite */
+            sol_tlog   const *tlog    /* logging callback      */
+           )
 {
-        unit_pass = 0;
-        unit_fail = 0;
+        register int i;
+
+                /* initialise counters and logging callback */
+        tsuite->total = 0;
+        tsuite->fail  = 0;
+        tsuite->tlog  = tlog;
+
+                /* initialise test case callback and description arrays */
+        for (i = 0; i < SOL_TSUITE_MAXTCASE; i++) {
+                *tsuite->desc [i] = '\0';
+                tsuite->tcase [i] = 0;
+        }
 }
 
 
 
 
 /*
- *      log_init() - initialises logging globals
- *        - path: path to log file
- *        - cbk : logging callback
- *
- *      The log_init() utility function initialises the logging global
- *      variables. It does so by assigning these variables the arguments passed
- *      through its parameters @path and @cbk. @path is copied on to the log
- *      file path global using the standard strncpy() algorithm. I'm not calling
- *      strncpy() directly as I would have to include the standard <string.h>
- *      header file which isn't available in freestanding environments.
- *
- *      This function assumes that both @path and @cbk are valid, leaving it up
- *      to the calling function to ensure that this is so.
+ *      sol_tsuite_init() - declared in sol/inc/test.h
  */
-static inline void
-log_init(char         const *path,
-         sol_test_log const *cbk
-        )
+extern sol_erno
+sol_tsuite_init(sol_tsuite *tsuite)
 {
-        register char *itr = log_path;
-        auto     int  len  = LOG_MAXPATHLEN;
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (tsuite, SOL_ERNO_PTR);
 
-        log_cbk = cbk;
+                /* initialise member fields, setting the logging callback to
+                 * null as we don't require it */
+        tsuite_init (tsuite, 0);
 
-        while (len-- && (*itr++ = *path++));
+SOL_CATCH:
+                /* throw exceptions */
+        sol_throw ();
 }
 
 
 
 
 /*
- *      sol_test_init() - declared in sol/inc/test.h
- *
- *      The sol_test_init() interface function needs only to initialise the unit
- *      test counters; it does so by calling the unit_init() utility function.
- *      It also sets the mod_init flag to 1 to indicate that unit testing module
- *      has been intialised.
- *
- *      The sol_test_init() function can't fail, so it always returns 0 to
- *      indicate that no error has occured.
+ *      sol_tsuite_init2() - declared in sol/inc/test.h
  */
-extern int
-sol_test_init(void)
+extern sol_erno
+sol_tsuite_init2(sol_tsuite       *tsuite,
+                 sol_tlog   const *tlog
+                )
 {
-        unit_init ();
-        mod_init = 1;
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (tsuite && tlog, SOL_ERNO_PTR);
 
-        return 0;
+                /* initialise member fields, setting the logging callback to
+                 * @tlog */
+        tsuite_init (tsuite, tlog);
+
+SOL_CATCH:
+                /* throw exceptions */
+        sol_throw ();
 }
 
 
 
 
 /*
- *      sol_test_init2() - declared in sol/inc/test.h
- *
- *      The sol_test_init2() interface function needs to initialise both the
- *      unit test counters and the logging global variables through the
- *      unit_init() and log_init() utility functions respectively. The logging
- *      variables are initialised only if the arguments to the parameters @path
- *      and @cbk are valid. Once initialisation is complete, the mod_init flag
- *      is set to 1 to indicate that the unit testing module has been set up.
- */
-extern int
-sol_test_init2(char         const *path,
-               sol_test_log const *cbk
-              )
-{
-        if (!(cbk && path && *path))
-                return SOL_ERNO_TEST;
-
-        unit_init ();
-        log_init (path, cbk);
-        mod_init = 1;
-
-        return 0;
-}
-
-
-
-
-/*
- *      sol_test_exit() - declared in sol/inc/test.h
- *
- *      The sol_test_exit() interface function resets the unit test counters to
- *      their default value, and sets the internal module initialisation flag to
- *      0 to indicate that unit testing module has been torn down.
- *
- *      This isn't  strictly necessary, but doing so keeps the internal state of
- *      the unit  testing module clean, and ensures that the other interface
- *      functions can't be called without first re-initialising the module.
+ *      sol_tsuite_term() - declared in sol/inc/test.h
  */
 extern void
-sol_test_exit(void)
+sol_tsuite_term(sol_tsuite *tsuite)
 {
-        unit_init ();
-        mod_init = 0;
+                /* reset member fields, including logging callback, if @tsuite
+                 * is valid */
+        if (tsuite)
+                tsuite_init (tsuite, 0);
 }
 
 
 
 
 /*
- *      sol_test_pass() - declared in sol/inc/test.h
- *
- *      The sol_test_pass() interface function returns the unit test pass
- *      counter through @pass after checking whether the unit testing module has
- *      been initialised and if @pass is valid.
+ *      sol_tsuite_register() - declared in sol/inc/test.h
  */
-extern int
-sol_test_pass(int *pass)
+extern sol_erno
+sol_tsuite_register(sol_tsuite       *tsuite,
+                    sol_tcase  const *tcase,
+                    char       const *desc
+                   )
 {
-        if (!(mod_init && pass))
-                return SOL_ERNO_TEST;
+        register char *itr;
+        auto     int  len;
 
-        *pass = unit_pass;
-        return 0;
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (tsuite && tcase && desc, SOL_ERNO_PTR);
+        sol_assert (*desc, SOL_ERNO_STR);
+        sol_assert (tsuite->total <= SOL_TSUITE_MAXTCASE, SOL_ERNO_RANGE);
+
+                /* add @tcase to first free slot in test case array; the index
+                 * of this slot will be equal to the current total number of
+                 * registed test cases */
+        tsuite->tcase [tsuite->total] = tcase;
+
+                /* add @desc to the first free slot in the test description
+                 * array using the strncpy() algorithm; its index will be the
+                 * same as that of the test case */
+        itr = tsuite->desc [tsuite -> total];
+        len = SOL_TCASE_MAXDESCLEN;
+        while (len-- && (*itr++ = *desc++));
+
+                /* update total number of registered test cases */
+        tsuite->total++;
+
+SOL_CATCH:
+                /* throw exceptions */
+        sol_throw ();
 }
 
 
 
 
 /*
- *      sol_test_fail() - declared in sol/inc/test.h
- *
- *      The sol_test_fail() interface function returns the unit test fail
- *      counter through @fail after checking whether the unit testing module has
- *      been initialised and if @fail is valid.
+ *      sol_tsuite_pass() - declared in sol/inc/test.h
  */
-extern int
-sol_test_fail(int *fail)
+extern sol_erno
+sol_tsuite_pass(sol_tsuite const *tsuite,
+                int              *pass
+               )
 {
-        if (!(mod_init && fail))
-                return SOL_ERNO_TEST;
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (tsuite && pass, SOL_ERNO_PTR);
 
-        *fail = unit_fail;
-        return 0;
+                /* return count of passed tests */
+        *pass = tsuite->total - tsuite->fail;
+
+SOL_CATCH:
+                /* throw exceptions */
+        sol_throw ();
 }
 
 
 
 
 /*
- *      sol_test_exec() - declared in sol/inc/test.h
- *
- *      The sol_test_exec() interface function runs the unit test @cbk, updating
- *      the appropriate test counter depending on whether @cbk passed or failed.
- *      Furthermore, the test result is logged by calling the logging callback
- *      function (if it's available). At the outset, this function checks  if
- *      the unit testing module has been intialised, and whether the arguments
- *      for @desc and @cbk are valid.
+ *      sol_tsuite_fail() - declared in sol/inc/test.h
  */
-extern int
-sol_test_exec(char          const *desc,
-              sol_test_unit const *cbk
-             )
+extern sol_erno
+sol_tsuite_fail(sol_tsuite const *tsuite,
+                int              *fail
+               )
 {
-        auto int erno;
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (tsuite && fail, SOL_ERNO_PTR);
 
-        if (!(mod_init && cbk && desc && *desc))
-                return SOL_ERNO_TEST;
+                /* return count of failed tests */
+        *fail = tsuite->fail;
 
-        if ((erno = cbk ()))
-                unit_fail ++;
-        else
-                unit_pass ++;
+SOL_CATCH:
+                /* throw exceptions */
+        sol_throw ();
+}
 
-        if (log_cbk)
-                log_cbk (desc, erno);
 
-        return erno;
+
+
+/*
+ *      sol_tsuite_total() - declared in sol/inc/test.h
+ */
+extern sol_erno
+sol_tsuite_total(sol_tsuite const *tsuite,
+                 int              *total
+                )
+{
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (tsuite && total, SOL_ERNO_PTR);
+
+                /* return count of total tests */
+        *total = tsuite->total;
+
+SOL_CATCH:
+                /* throw exceptions */
+        sol_throw ();
+}
+
+
+
+
+/*
+ *      sol_tsuite_exec() - declared in sol/inc/test.h
+ */
+extern sol_erno
+sol_tsuite_exec(sol_tsuite *tsuite)
+{
+        register int      i;
+        auto     sol_erno erno;
+
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (tsuite, SOL_ERNO_PTR);
+
+                /* reset count of failed test cases */
+        tsuite->fail = 0;
+
+                /* iterate through test case array, executing each in turn and
+                 * logging it if the logging callback is available; update count
+                 * of failed test cases as required */
+        for (i = 0; i < tsuite->total; i++) {
+                if ((erno = tsuite->tcase [i] ()))
+                        tsuite->fail++;
+
+                if (tsuite->tlog)
+                        tsuite->tlog (tsuite->desc [i], erno);
+        }
+
+SOL_CATCH:
+                /* throw exceptions */
+        sol_throw ();
 }
 
 


### PR DESCRIPTION
The unit testing module is now thread-safe as its implementation no
longer depends on module level global variables. The unit testing module
has been re-implemented as a new type sol_tsuite that abstracts a test
suite. Testing for this new implementation is still pending.

This pull request closes #11.