### PR TITLE
Add compiler hints module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,10 @@ OPT_COV = -o $(DIR_BLD)
 
 # 	Set command inputs
 INP_SO  = $(DIR_BLD)/test.o
-INP_LD  = $(DIR_TEST)/runner.c $(DIR_TEST)/error.t.c $(DIR_TEST)/test.t.c
+INP_LD  = $(DIR_TEST)/runner.c $(DIR_TEST)/error.t.c $(DIR_TEST)/test.t.c \
+	  $(DIR_TEST)/hint.t.c
 INP_COV = $(DIR_BLD)/test.gcda $(DIR_BLD)/runner.gcda $(DIR_BLD)/error.t.gcda \
-	  $(DIR_BLD)/test.t.gcda
+	  $(DIR_BLD)/test.t.gcda $(DIR_BLD)/hint.t.gcda
 INP_RUN = $(DIR_BLD)/test.log
 
 

--- a/inc/error.h
+++ b/inc/error.h
@@ -33,6 +33,7 @@
 
 
 
+#include "./hint.h"
 #include <stddef.h>
 
 
@@ -216,12 +217,14 @@ typedef size_t sol_erno;
  *      predicate @p, is true before any further processing takes place. This
  *      macro can only be called within a SOL_TRY block. If the assertion fails,
  *      then a sol_erno error code @e is thrown and control jumps to the
- *      adjacent SOL_CATCH block. This macro should **never** be called within a
- *      SOL_CATCH block as it may potentially lead to an infinite loop.
+ *      adjacent SOL_CATCH block.
+ *
+ *      This macro should **never** be called within a SOL_CATCH block as it may
+ *      potentially lead to an infinite loop.
  */
 #define /* void */ sol_assert(p, /* sol_erno */ e) \
         do {                                       \
-                if (!(p)) {                        \
+                if (sol_unlikely (!(p))) {         \
                         __sol_erno = (e);          \
                         goto __SOL_CATCH;          \
                 }                                  \
@@ -239,14 +242,16 @@ typedef size_t sol_erno;
  *      deemed to have run successfully if it has not thrown any exception as
  *      flagged by the returned error code. This macro can only be called within
  *      a SOL_TRY block. If the validation fails, then control will jump to the
- *      adjacent SOL_CATCH block. As with the sol_assert() macro, this macro
- *      should **never** be called within a SOL_CATCH block as it may
- *      potentially lead to an infinite loop.
+ *      adjacent SOL_CATCH block.
+ *
+ *      As with the sol_assert() macro, this macro should **never** be called
+ *      within a SOL_CATCH block as it may potentially lead to an infinite loop.
  */
-#define /* void */ sol_try(p)             \
-        do {                              \
-                if ((__sol_erno = (p)))   \
-                        goto __SOL_CATCH; \
+#define /* void */ sol_try(p)                            \
+        do {                                             \
+                if (sol_unlikely ((__sol_erno = (p)))) { \
+                        goto __SOL_CATCH;                \
+                }                                        \
         } while (0)
 
 

--- a/inc/hint.h
+++ b/inc/hint.h
@@ -1,0 +1,169 @@
+/******************************************************************************
+ *                           SOL LIBRARY v0.1.0+41
+ *
+ * File: sol/inc/hint.h
+ *
+ * Description:
+ *      This file is part of the API of the Sol Library. It declares the
+ *      interface of the compiler hints module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+#if !defined __SOL_COMPILER_HINTS_MODULE
+#define __SOL_COMPILER_HINTS_MODULE
+
+
+
+
+/*
+ *      sol_hot - hot code hint
+ *
+ *      The sol_hot symbolic constant provides a compiler hint that the code of
+ *      the function it is associated with is frequently called. Using this hint
+ *      helps to provide compile-time optimisations to the associated code. This
+ *      hint is available on GCC-compatible compilation environments, and
+ *      degrades gracefully to a safe no-op on other environments.
+ */
+#if (defined __GNUC__) || (defined __clang__)
+#       define sol_hot __attribute__((hot))
+#else
+#       define sol_hot
+#endif
+
+
+
+
+/*
+ *      sol_cold - cold code hint
+ *
+ *      The sol_cold symbolic constant provides a compiler hint that the code of
+ *      the function it is associated with is rarely called. Using this hint
+ *      helps to provide compile-time optimisations to the associated code. This
+ *      hint is available on GCC-compatible compilation environments, and
+ *      degrades gracefully to a safe no-op on other environments.
+ */
+#if (defined __GNUC__) || (defined __clang__)
+#       define sol_cold __attribute__((cold))
+#else
+#       define sol_cold
+#endif
+
+
+
+
+/*
+ *      sol_likely() - hint that predicate is likely to be true
+ *        - p: predicate to evaluate
+ *
+ *      The sol_likely() macro provides a branch prediction hint to the
+ *      compiler, indicating that a predicate @p is likely to be true. This
+ *      macro is modelled after the likely() macro in the Linux kernel, and
+ *      relies on a GCC-specific extension. However, this macro degrades
+ *      gracefully to a safe no-op on non-GCC compatible compilation platforms.
+ *
+ *      @p is expected to be an integral predicate expression that evaluates to
+ *      a Boolean value.
+ *
+ *      Return:
+ *        - 0 if @p evaluates to false
+ *        - 1 if @p evaluates to true
+ */
+#if (defined __GNUC__) || (defined __clang__)
+#       define sol_likely(p) (__builtin_expect(!!(p), 1))
+#else
+#       define sol_likely(p) (p)
+#endif
+
+
+
+
+/*
+ *      sol_unlikely() - hint that predicate is unlikely to be true
+ *        - p: predicate to evaluate
+ *
+ *      The sol_unlikely() macro provides a branch prediction hint to the
+ *      compiler, indicating that a predicate @p is unlikely to be true. This
+ *      macro is modelled after the unlikely() macro in the Linux kernel, and
+ *      relies on a GCC-specific extension. However, this macro degrades
+ *      gracefully to a safe no-op on non-GCC compatible compilation platforms.
+ *
+ *      @p is expected to be an integral predicate expression that evaluates to
+ *      a Boolean value.
+ *
+ *      Return:
+ *        - 0 if @p evaluates to false
+ *        - 1 if @p evaluates to true
+ */
+#if (defined __GNUC__) || (defined __clang__)
+#       define sol_unlikely(p) (__builtin_expect(!!(p), 0))
+#else
+#       define sol_unlikely(p) (p)
+#endif
+
+
+
+
+/*
+ *      sol_likely - hint that function should be inlined
+ *
+ *      The sol_inline symbolic constant provides a mechanism to portably hint
+ *      to the compiler that a given function should be considered for inlining.
+ *      This symbol expands to the inline keyword when C99 and above is used,
+ *      and gracefully degrades on earlier versions.
+ *
+ *      If inlining is essential in C89/C90, then the only way out is to declare
+ *      the inline code as a macro, optionally wrapped in a do-while(0) loop.
+ */
+#if (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L)
+#       define sol_inline inline
+#else
+#       define sol_inline
+#endif
+
+
+
+
+/*
+ *      sol_restrict - hint that a pointer is restricted
+ *
+ *      The sol_restrict symbolic constant provides a mechanism to portably hint
+ *      to the compiler that a given pointer should be considered as restricted.
+ *      This symbol expands to the restrict keyword when C99 and above is used,
+ *      and gracefully degrades on earlier versions.
+ */
+#if (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L)
+#       define sol_restrict restrict
+#else
+#       define sol_restrict
+#endif
+
+
+
+
+#endif /* !defined __SOL_COMPILER_HINTS_MODULE */
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/test/hint.t.c
+++ b/test/hint.t.c
@@ -1,0 +1,564 @@
+/******************************************************************************
+ *                           SOL LIBRARY v1.0.0+41
+ *
+ * File: sol/test/hint.t.c
+ *
+ * Description:
+ *      This file is part of the internal quality checking of the Sol Library.
+ *      It implements the test suite for the compiler hints module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+#include "./suite.h"
+#include "../inc/hint.h"
+
+
+
+
+/*
+ *      gcc_off() - toggles GCC compiler identification off
+ */
+static void gcc_off(void)
+{
+        #if (defined __GNUC__)
+                #define __sol_test_hint_gcc __GNUC__
+                #undef __GNUC__
+        #endif
+}
+
+
+
+
+/*
+ *      clang_off() - toggles CLang compiler identification off
+ */
+static void clang_off(void)
+{
+        #if (defined __clang__)
+                #define __sol_test_hint_clang __clang__
+                #undef __clang__
+        #endif
+}
+
+
+
+
+/*
+ *      gcc_on() - toggles GCC compiler identification on
+ */
+static void gcc_on(void)
+{
+        #if (defined __sol_test_hint_gcc)
+        #       define __GNUC__ __sol_test_hint_gcc
+        #       undef __sol_test_hint_gcc
+        #endif
+}
+
+
+
+
+/*
+ *      clang_on() - toggles CLang compiler identification on
+ *
+ */
+static void clang_on(void)
+{
+        #if (defined __sol_test_hint_clang)
+        #       define __clang__ __sol_test_hint_clang
+        #       undef __sol_test_hint_clang
+        #endif
+}
+
+
+
+
+/*
+ *      mock_hot() - mocks definition of hot function
+ */
+static sol_hot int mock_hot(void)
+{
+        return 1;
+}
+
+
+
+
+/*
+ *      mock_cold() - mocks definition of cold function
+ */
+static sol_cold int mock_cold(void)
+{
+        return 1;
+}
+
+
+
+
+/*
+ *      mock_inline() - mocks definition of inline function
+ */
+static sol_inline int mock_inline(void)
+{
+        return 1;
+}
+
+
+
+
+/*
+ *      mock_restrict() - mocks use of restrict pointer
+ */
+static int mock_restrict(int *sol_restrict ptr)
+{
+        *ptr = 1;
+        return *ptr;
+}
+
+
+
+
+/*
+ *      likely_01() - sol_likely() unit test #1
+ */
+#if (defined __GNUC__ || defined __clang__)
+static sol_erno likely_01(void)
+{
+        #define LIKELY_01 "A predicate evaluates correctly to True with a"     \
+                          " likely branch prediction hint on a GCC-compatible" \
+                          " compiler"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sol_likely (1), SOL_ERNO_TEST);
+
+SOL_CATCH:
+        sol_throw();
+}
+#endif /* (defined __GNUC__ || defined __clang__) */
+
+
+
+
+/*
+ *      likely_02() - sol_likely() unit test #2
+ */
+#if (defined __GNUC__ || defined __clang__)
+static sol_erno likely_02(void)
+{
+        #define LIKELY_02 "A predicate evaluates correctly to False with a"    \
+                          " likely branch prediction hint on a GCC-compatible" \
+                          " compiler"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (!sol_likely (0), SOL_ERNO_TEST);
+
+SOL_CATCH:
+        sol_throw();
+}
+#endif /* (defined __GNUC__ || defined __clang__) */
+
+
+
+
+/*
+ *      likely_03() - sol_likely() unit test #3
+ */
+static sol_erno likely_03(void)
+{
+        #define LIKELY_03 "A predicate evaluates correctly to True with a" \
+                          " likely branch prediction hint on a non GCC-"   \
+                          " compatible compiler"
+
+SOL_TRY:
+                /* set up test scenario */
+        gcc_off();
+        clang_off();
+
+                /* check test condition */
+        sol_assert (sol_likely (1), SOL_ERNO_TEST);
+        gcc_on();
+        clang_on();
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        gcc_on();
+        clang_on();
+        sol_throw();
+}
+
+
+
+
+/*
+ *      likely_04() - sol_likely() unit test #4
+ */
+static sol_erno likely_04(void)
+{
+        #define LIKELY_04 "A predicate evaluates correctly to False with a" \
+                          " likely branch prediction hint on a non GCC-"    \
+                          "compatible compiler"
+
+SOL_TRY:
+                /* set up test scenario */
+        gcc_off();
+        clang_off();
+
+                /* check test condition */
+        sol_assert (!sol_likely (0), SOL_ERNO_TEST);
+        gcc_on();
+        clang_on();
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        gcc_on();
+        clang_on();
+        sol_throw();
+}
+
+
+
+
+/*
+ *      unlikely_01() - sol_unlikely() unit test #1
+ */
+#if (defined __GNUC__ || defined __clang__)
+static sol_erno unlikely_01(void)
+{
+        #define UNLIKELY_01 "A predicate evaluates correctly to True with an" \
+                            " unlikely branch prediction hint on a GCC-"      \
+                            "compatible compiler"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sol_unlikely (1), SOL_ERNO_TEST);
+
+SOL_CATCH:
+        sol_throw();
+}
+#endif /* (defined __GNUC__ || defined __clang__) */
+
+
+
+
+/*
+ *      unlikely_02() - sol_unlikely() unit test #2
+ */
+#if (defined __GNUC__ || defined __clang__)
+static sol_erno unlikely_02(void)
+{
+        #define UNLIKELY_02 "A predicate evaluates correctly to False with an" \
+                            " unlikely branch prediction hint on a GCC-"       \
+                            "compatible compiler"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (!sol_unlikely (0), SOL_ERNO_TEST);
+
+SOL_CATCH:
+        sol_throw();
+}
+#endif /* (defined __GNUC__ || defined __clang__) */
+
+
+
+
+/*
+ *      unlikely_03() - sol_unlikely() unit test #3
+ */
+static sol_erno unlikely_03(void)
+{
+        #define UNLIKELY_03 "A predicate evaluates correctly to True with an" \
+                            " unlikely branch prediction hint on a non GCC-"  \
+                            "compatible compiler"
+
+SOL_TRY:
+                /* set up test scenario */
+        gcc_off();
+        clang_off();
+
+                /* check test condition */
+        sol_assert (sol_unlikely (1), SOL_ERNO_TEST);
+        gcc_on();
+        clang_on();
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        gcc_on();
+        clang_on();
+        sol_throw();
+}
+
+
+
+
+/*
+ *      unlikely_04() - sol_unlikely() unit test #4
+ */
+static sol_erno unlikely_04(void)
+{
+        #define UNLIKELY_04 "A predicate evaluates correctly to False with an" \
+                            " unlikely branch prediction hint on a non GCC-"   \
+                            "compatible compiler"
+
+SOL_TRY:
+                /* set up test scenario */
+        gcc_off();
+        clang_off();
+
+                /* check test condition */
+        sol_assert (!sol_unlikely (0), SOL_ERNO_TEST);
+        gcc_on();
+        clang_on();
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        gcc_on();
+        clang_on();
+        sol_throw();
+}
+
+
+
+
+/*
+ *      hot_01() - sol_hot unit test #1
+ */
+static sol_erno hot_01(void)
+{
+        #define HOT_01 "A function marked hot executes successfully on a GCC-" \
+                       "compatible compiler"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (mock_hot(), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      hot_02() - sol_hot unit test #2
+ */
+static sol_erno hot_02(void)
+{
+        #define HOT_02 "A function marked hot executes successfully on a non " \
+                       " GCC-compatible compiler"
+
+SOL_TRY:
+                /* set up test scenario */
+        gcc_off();
+        clang_off();
+
+                /* check test condition */
+        sol_assert (mock_hot(), SOL_ERNO_TEST);
+        gcc_on();
+        clang_on();
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        gcc_on();
+        clang_on();
+        sol_throw();
+}
+
+
+
+
+/*
+ *      cold_01() - sol_cold unit test #1
+ */
+static sol_erno cold_01(void)
+{
+        #define COLD_01 "A function marked cold executes successfully on a" \
+                        " GCC-compatible compiler"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (mock_cold(), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      cold_02() - sol_cold unit test #2
+ */
+static sol_erno cold_02(void)
+{
+        #define COLD_02 "A function marked cold executes successfully on a" \
+                        " non GCC-compatible compiler"
+
+SOL_TRY:
+                /* set up test scenario */
+        gcc_off();
+        clang_off();
+
+                /* check test condition */
+        sol_assert (mock_cold(), SOL_ERNO_TEST);
+        gcc_on();
+        clang_on();
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        gcc_on();
+        clang_on();
+        sol_throw();
+}
+
+
+
+
+/*
+ *      inline_01() - sol_inline unit test #1
+ */
+static sol_erno inline_01(void)
+{
+        #define INLINE_01 "A function marked inline executes successfully on" \
+                          " a GCC-compatible compiler"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (mock_inline(), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      inline_02() - sol_inline unit test #2
+ */
+static sol_erno inline_02(void)
+{
+        #define INLINE_02 "A function marked inline executes successfully on" \
+                          " a non GCC-compatible compiler"
+
+SOL_TRY:
+                /* set up test scenario */
+        gcc_off();
+        clang_off();
+
+                /* check test condition */
+        sol_assert (mock_inline(), SOL_ERNO_TEST);
+        gcc_on();
+        clang_on();
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        gcc_on();
+        clang_on();
+        sol_throw();
+}
+
+
+
+
+/*
+ *      restrict_01() - sol_restrict unit test #1
+ */
+static sol_erno restrict_01(void)
+{
+        #define RESTRICT_01 "A pointer marked restricted behaves as expected"
+        auto int tmp = 0;
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (mock_restrict(&tmp), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      __sol_hint_test() - declared in sol/test/suite.h
+ */
+extern sol_erno __sol_tsuite_hint(sol_tlog *log,
+                                  int *pass,
+                                  int *fail,
+                                  int *total)
+{
+        auto sol_tsuite __ts, *ts = &__ts;
+
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (log && pass && fail && total, SOL_ERNO_PTR);
+
+
+                /* register non GCC-compatible specific test cases */
+        sol_try (sol_tsuite_init2(ts, log));
+        sol_try (sol_tsuite_register(ts, &likely_03, LIKELY_03));
+        sol_try (sol_tsuite_register(ts, &likely_04, LIKELY_04));
+        sol_try (sol_tsuite_register(ts, &unlikely_01, UNLIKELY_01));
+        sol_try (sol_tsuite_register(ts, &unlikely_04, UNLIKELY_04));
+        sol_try (sol_tsuite_register(ts, &hot_01, HOT_01));
+        sol_try (sol_tsuite_register(ts, &hot_02, HOT_02));
+        sol_try (sol_tsuite_register(ts, &cold_01, COLD_01));
+        sol_try (sol_tsuite_register(ts, &cold_02, COLD_02));
+        sol_try (sol_tsuite_register(ts, &inline_01, INLINE_01));
+        sol_try (sol_tsuite_register(ts, &inline_02, INLINE_02));
+                sol_try (sol_tsuite_register(ts, &restrict_01, RESTRICT_01));
+
+                /* register GCC-compatible specific test cases */
+        #if (defined __GNUC__ || defined __clang__)
+                sol_try (sol_tsuite_register(ts, &likely_01, LIKELY_01));
+                sol_try (sol_tsuite_register(ts, &likely_02, LIKELY_02));
+                sol_try (sol_tsuite_register(ts, &unlikely_02, UNLIKELY_02));
+                sol_try (sol_tsuite_register(ts, &unlikely_03, UNLIKELY_03));
+        #endif
+
+                /* execute test cases */
+        sol_try (sol_tsuite_exec(ts));
+
+                /* report test counts */
+        sol_try (sol_tsuite_pass(ts, pass));
+        sol_try (sol_tsuite_fail(ts, fail));
+        sol_try (sol_tsuite_total(ts, total));
+        sol_tsuite_term(ts);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_tsuite_term(ts);
+        sol_throw();
+}
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/test/runner.c
+++ b/test/runner.c
@@ -43,14 +43,10 @@ typedef sol_erno        /* error code                */
        );
 
 
-
-
 /*
  *      SUITE_COUNT - count of test suites
  */
-#define SUITE_COUNT 2
-
-
+#define SUITE_COUNT 3
 
 
 /*
@@ -59,11 +55,17 @@ typedef sol_erno        /* error code                */
 #define SUITE_ERROR 0
 
 
-
 /*
  *      SUITE_TEST - index of unit testing module test suite
  */
 #define SUITE_TEST 1
+
+
+/*
+ *      SUITE_HINT - index of the compiler hints module test suite
+ */
+#define SUITE_HINT 2
+
 
 
 
@@ -252,9 +254,9 @@ stat_sum(void)
 
                 /* sum test suite statistics */
         for (i = 0; i < SUITE_COUNT; i++) {
-                stat_sigma.pass  += stat_suite.pass  [i];
-                stat_sigma.fail  += stat_suite.fail  [i];
-                stat_sigma.total += stat_suite.total [i];
+                stat_sigma.pass += stat_suite.pass[i];
+                stat_sigma.fail += stat_suite.fail[i];
+                stat_sigma.total += stat_suite.total[i];
         }
 }
 
@@ -270,6 +272,7 @@ suite_init(void)
                 /* register test suites */
         suite_hnd [SUITE_ERROR] = __sol_tsuite_error;
         suite_hnd [SUITE_TEST]  = __sol_tsuite_test;
+        suite_hnd [SUITE_HINT]  = __sol_tsuite_hint;
 }
 
 
@@ -299,21 +302,22 @@ suite_exec(void)
 /*
  *      main() - main entry point of test runner
  */
-int main(int argc, char **argv)
+int main(int argc,
+         char **argv)
 {
                 /* initialise */
-        log_init   (argc, argv);
-        stat_init  ();
-        suite_init ();
+        log_init(argc, argv);
+        stat_init();
+        suite_init();
 
                 /* execute */
-        suite_exec ();
-        stat_sum   ();
-        log_sigma  ();
+        suite_exec();
+        stat_sum();
+        log_sigma();
 
                 /* terminate */
-        log_term ();
-        return 0;
+        log_term();
+        return stat_sigma.fail;
 }
 
 

--- a/test/suite.h
+++ b/test/suite.h
@@ -27,14 +27,10 @@
 
 
 #if !defined __SOL_LIBRARY_TEST_SUITES
-#define      __SOL_LIBRARY_TEST_SUITES
-
-
+#define __SOL_LIBRARY_TEST_SUITES
 
 
 #include "../inc/test.h"
-
-
 
 
 /*
@@ -48,8 +44,6 @@ __sol_tsuite_error(sol_tlog *log,
                   );
 
 
-
-
 /*
  *      __sol_tsuite_test() - test suite for unit testing module
  */
@@ -61,6 +55,13 @@ __sol_tsuite_test(sol_tlog *log,
                  );
 
 
+/*
+ *      __sol_tsuite_hint() - test suite for compiler hints module
+ */
+extern sol_erno __sol_tsuite_hint(sol_tlog *log,
+                                  int *pass,
+                                  int *fail,
+                                  int *total);
 
 
 #endif /* !defined __SOL_LIBRARY_TEST_SUITES */

--- a/test/test.t.c
+++ b/test/test.t.c
@@ -25,7 +25,6 @@
 
 
 #include "./suite.h"
-#include <stdio.h>
 
 
 /*


### PR DESCRIPTION
The compiler hints module provides language extensions through symbolic
constants and macros that allow for portable optimisation of C code. The
following hints have been defined:
  * sol_likely()
  * sol_unlikely()
  * sol_hot
  * sol_cold
  * sol_inline
  * sol_restrict

The unit test have also been prepared as appropriate, with specific
checks to ensure portability on non-GCC/CLang compilers. Furthermore,
the sol_assert() and sol_try() macros of the exception handling module
have been enhanced with the incorporation of sol_unlikely() hints.

This pull request closes #24.