### PR TITLE
Add environment module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ OPT_COV = -o $(DIR_BLD)
 # 	Set command inputs
 INP_SO  = $(DIR_BLD)/test.o
 INP_LD  = $(DIR_TEST)/runner.c $(DIR_TEST)/error.t.c $(DIR_TEST)/test.t.c \
-	  $(DIR_TEST)/hint.t.c
+	  $(DIR_TEST)/hint.t.c $(DIR_TEST)/env.t.c
 INP_COV = $(DIR_BLD)/test.gcda $(DIR_BLD)/runner.gcda $(DIR_BLD)/error.t.gcda \
-	  $(DIR_BLD)/test.t.gcda $(DIR_BLD)/hint.t.gcda
+	  $(DIR_BLD)/test.t.gcda $(DIR_BLD)/hint.t.gcda $(DIR_BLD)/env.t.gcda
 INP_RUN = $(DIR_BLD)/test.log
 
 

--- a/inc/env.h
+++ b/inc/env.h
@@ -1,0 +1,332 @@
+/******************************************************************************
+ *                           SOL LIBRARY v0.1.0+41
+ *
+ * File: sol/inc/env.h
+ *
+ * Description:
+ *      This file is part of the API of the Sol Library. It declares the
+ *      interface of the environment module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+#if (!defined __SOL_ENVIRONMENT_MODULE)
+#define __SOL_ENVIRONMENT_MODULE
+
+
+
+
+/*
+ *      SOL_ENV_CC - enumerates supported C compilers
+ *        - SOL_ENV_CC_GNUC : GNU C or GNU C compatible compiler
+ *        - SOL_ENV_CC_CLANG: CLang front-end of LLVM compiler
+ *
+ *      The SOL_ENV_CC type enumerates the C compilers that are supported by the
+ *      Sol Library. The constants enumerated by this type are returned by the
+ *      sol_env_cc() macro (defined below) in order to indicate the C compiler
+ *      being used at compile-time.
+ *
+ *      Currently, only GNU C and CLang compilers are supported directly, and
+ *      GNU C compatible compilers indirectly. This is expected to be adequate
+ *      as far as portability is concerned, as GNU C is the most widely ported C
+ *      compiler. However, in future, support for other compilers, including
+ *      MSVC, *may* be introduced if there is adequate reason to do so.
+ */
+typedef enum __SOL_ENV_CC {
+        SOL_ENV_CC_GNUC,
+        SOL_ENV_CC_CLANG
+} SOL_ENV_CC;
+
+
+
+
+/*
+ *      SOL_ENV_STDC - enumerates supported C language standards
+ *        - SOL_ENV_STDC_C89: C89 standard
+ *        - SOL_ENV_STDC_C90: C90 standard
+ *        - SOL_ENV_STDC_C94: C94 standard
+ *        - SOL_ENV_STDC_C99: C99 standard
+ *        - SOL_ENV_STDC_C11: C11 standard
+ *        - SOL_ENV_STDC_C18: C18 standard
+ *
+ *      The SOL_ENV_STDC type enumerates the C language standards that are
+ *      supported by the Sol Library. The constants enumerated by this type are
+ *      used by the sol_env_stdc() macro (defined below) in order to indicate
+ *      the compile-time C standard being used.
+ *
+ *      The Sol Library is designed to be backward-compatible with the C89
+ *      standard, while taking advantage of some of the new features introduced
+ *      by the modern standards. Backward-compatiblity with the C89 standard
+ *      ensures maximum portability; dialects predating the C89 standard are not
+ *      considered, as they are fairly archaic and limited only to deprecated
+ *      compilers.
+ */
+typedef enum __SOL_ENV_STDC {
+        SOL_ENV_STDC_C89,
+        SOL_ENV_STDC_C90,
+        SOL_ENV_STDC_C94,
+        SOL_ENV_STDC_C99,
+        SOL_ENV_STDC_C11,
+        SOL_ENV_STDC_C18
+} SOL_ENV_STDC;
+
+
+
+
+/*
+ *      SOL_ENV_HOST - enumerates supported host platforms
+ *        - SOL_ENV_HOST_NONE   : Freestanding environment
+ *        - SOL_ENV_HOST_ANDROID: Android
+ *        - SOL_ENV_HOST_LINUX  : All other flavours of Linux
+ *        - SOL_ENV_HOST_CYGWIN : Cygwin on Microsoft Windows
+ *        - SOL_ENV_HOST_BSD    : All BSD variants
+ *        - SOL_ENV_HOST_HPUX   : HP-UX
+ *        - SOL_ENV_HOST_AIX    : IBM AIX
+ *        - SOL_ENV_HOST_IOS    : Apple iOS
+ *        - SOL_ENV_HOST_OSX    : Apple OSX
+ *        - SOL_ENV_HOST_SOLARIS: Oracle Solaris / Open Indiana
+ *
+ *      The SOL_ENV_HOST type enumerates the host platforms that are supported
+ *      by the Sol Library. The constants enumerated by this type are returned
+ *      by the sol_env_host() macro (defined below) in order to indicate the
+ *      compile-time host platform.
+ *
+ *      The Sol Library has been designed to support both freestanding and POSIX
+ *      compliant hosted platforms; however, as of now, only the Linux platform
+ *      has been tested, and support for the others being assumed based on these
+ *      tests.
+ */
+typedef enum __SOL_ENV_HOST {
+        SOL_ENV_HOST_NONE,
+        SOL_ENV_HOST_ANDROID,
+        SOL_ENV_HOST_LINUX,
+        SOL_ENV_HOST_CYGWIN,
+        SOL_ENV_HOST_BSD,
+        SOL_ENV_HOST_HPUX,
+        SOL_ENV_HOST_AIX,
+        SOL_ENV_HOST_IOS,
+        SOL_ENV_HOST_OSX,
+        SOL_ENV_HOST_SOLARIS
+} SOL_ENV_HOST;
+
+
+
+
+/*
+ *      SOL_ENV_ARCH - enumerates supported CPU architectures
+ *        - SOL_ENV_ARCH_X68  : 32-bit x86 processor
+ *        - SOL_ENV_ARCH_AMD64: 64-bit x86_64 processor
+ *        - SOL_ENV_ARCH_IA64 : 64-bit Itanium processor
+ *
+ *      The SOL_ENV_ARCH type enumerates the CPU architectures supported by the
+ *      Sol Library. The constants enumerated by this type are returned by the
+ *      sol_env_host() macro (defined below) in order to indicate the processor
+ *      architecture at compile-time.
+ *
+ *      The Sol Library currently supports the 32-bit x86 family of processors,
+ *      and the 64-bit x86_64 and Itanium family of processors. The Sol Library
+ *      has been tested on the x86_64 architecture, and support for the others
+ *      is assumed based on these tests.
+ */
+typedef enum __SOL_ENV_ARCH {
+        SOL_ENV_ARCH_X86,
+        SOL_ENV_ARCH_AMD64,
+        SOL_ENV_ARCH_IA64
+} SOL_ENV_ARCH;
+
+
+
+
+/*
+ *      sol_env_cc() - determines C compiler at compile-time
+ *
+ *      The sol_env_cc() macro determines at compile-time the C compiler that is
+ *      being used. This macro returns one of the constants enumerated by the
+ *      SOL_ENV_CC type as appropriate. A compile-time error is raised in case
+ *      an unsupported compiler is detected.
+ *
+ *      Return:
+ *        - SOL_ENV_CC_GNUC if GNU C or GNU C compatible compiler detected
+ *        - SOL_ENV_CC_CLANG if CLang compiler detected
+ */
+#if (defined __GNUC__)
+#       define sol_env_cc() SOL_ENV_CC_GNUC
+#elif (defined __clang__)
+#       define sol_env_cc() SOL_ENV_CC_CLANG
+#else
+#       error "[!] sol_env_cc() error: unsupported C compiler"
+#endif
+
+
+
+
+/*
+ *      sol_env_stdc() - determines compile-time C language standard
+ *
+ *      The sol_env_stdc() macro determines at compile-time the C language
+ *      standard that is being used. This macro returns one of the constants
+ *      enumerated by the SOL_ENV_STDC type as appropriate. A compile-time error
+ *      is raised in case an unsupported standard is detected.
+ *
+ *      Return:
+ *        - SOL_ENV_STDC_C89 if C89 standard detected
+ *        - SOL_ENV_STDC_C90 if C90 standard detected
+ *        - SOL_ENV_STDC_C94 if C94 standard detected
+ *        - SOL_ENV_STDC_C99 if C99 standard detected
+ *        - SOL_ENV_STDC_C11 if C11 standard detected
+ *        - SOL_ENV_STDC_C18 if C18 standard detected
+ *
+ */
+#if (defined __STDC__)
+#       if (defined __STDC_VERSION__)
+#               if (__STDC_VERSION__ >= 201710L)
+#                       define sol_env_stdc() SOL_ENV_STDC_C18
+#               elif (__STDC_VERSION__ >= 201112L)
+#                       define sol_env_stdc() SOL_ENV_STDC_C11
+#               elif (__STDC_VERSION__ >= 199901L)
+#                       define sol_env_stdc() SOL_ENV_STDC_C99
+#               elif (__STDC_VERSION__ >= 199409L)
+#                       define sol_env_stdc() SOL_ENV_STDC_C94
+#               else
+#                       define sol_env_stdc() SOL_ENV_STDC_C90
+#               endif
+#       else
+#               define sol_env_stdc() SOL_ENV_STDC_C89
+#       endif
+#else
+#       error "[!] sol_env_stdc() error: unsupported C language standard"
+#endif
+
+
+
+
+/*
+ *      sol_env_host() - determines compile-time host platform
+ *
+ *      The sol_env_host() macro determines at compile-time the host platform
+ *      that is being used. This macro returns one of the constants enumerated
+ *      by the SOL_ENV_HOST type as appropriate. A compile-time error is raised
+ *      in case an unsupported host is detected.
+ *
+ *      Return:
+ *        - SOL_ENV_HOST_NONE if freestanding environment detected
+ *        - SOL_ENV_HOST_ANDROID if Android detected
+ *        - SOL_ENV_HOST_LINUX if other Linux flavour detected
+ *        - SOL_ENV_HOST_CYGWIN if Cygwin on Microsoft Windows detected
+ *        - SOL_ENV_HOST_BSD if a BSD variant detected
+ *        - SOL_ENV_HOST_HPUX if HP-UX detected
+ *        - SOL_ENV_HOST_AIX if IBM AIX detected
+ *        - SOL_ENV_HOST_IOS if Apple iOS detected
+ *        - SOL_ENV_HOST_OSX if Apple OSX detected
+ *        - SOL_ENV_HOST_SOLARIS if Oracle Solaris / Open Indiana detected
+ */
+#if (defined __CYGWIN__)
+#       define sol_env_host() SOL_ENV_HOST_CYGWIN
+#elif (defined __ANDROID__)
+#       define sol_env_host() SOL_ENV_HOST_ANDROID
+#elif (defined __linux__)
+#       define sol_env_host() SOL_ENV_HOST_LINUX
+#elif (defined __hpux)
+#       define sol_env_host() SOL_ENV_HOST_HPUX
+#elif (defined _AIX)
+#       define sol_env_host() SOL_ENV_HOST_AIX
+#elif (defined __sun && defined __SVR4)
+#       define sol_env_host() SOL_ENV_HOST_SOLARIS
+#elif (defined __unix__)
+#       include <sys/param.h>
+#       if (defined BSD)
+#               define sol_env_host() SOL_ENV_HOST_BSD
+#       endif
+#elif (defined __APPLE__ && defined __MACH__)
+#       include <TargetConditionals.h>
+#       if (1 == TARGET_IPHONE_SIMULATOR || 1 == TARGET_OS_IPHONE)
+#               define sol_env_host() SOL_ENV_HOST_IOS
+#       elif (1 == TARGET_OS_MAC)
+#               define sol_env_host() SOL_ENV_HOST_OSX
+#       endif
+#else
+#       error "[!] sol_env_host() error: unsupported host platform"
+#endif
+
+
+
+
+/*
+ *      sol_env_arch() - determines compile-time CPU architecture
+ *
+ *      The sol_env_arch() macro determines at compile-time the processor
+ *      architecture that is being used. This macro returns one of the constants
+ *      enumerated by the SOL_ENV_ARCH type as appropriate. A compile-time error
+ *      is raised in case an unsupported architecture is detected.
+ *
+ *      Return:
+ *        - SOL_ENV_ARCH_X68 if 32-bit x86 processor detected
+ *        - SOL_ENV_ARCH_AMD64 if 64-bit x86_64 processor detected
+ *        - SOL_ENV_ARCH_IA64 if 64-bit Itanium processor detected
+ */
+#if (defined __amd64__ || defined __amd64                          \
+     || defined __x86_64__  || defined __x86_64)
+#       define sol_env_arch() SOL_ENV_ARCH_AMD64
+#elif (defined __ia64__ || defined __IA64__ || defined _IA64)
+#       define sol_env_arch() SOL_ENV_ARCH_IA64
+#elif (defined i386 || defined __i386 || defined __i386__          \
+       || defined __i486__ || defined __i586__ || defined __i686__)
+#       define sol_env_arch() SOL_ENV_ARCH_X86
+#else
+#       error "[!] sol_env_arch() error: unsupported architecture"
+#endif
+
+
+
+
+/*
+ *      sol_env_wordsz() - determines compile-time native word size
+ *
+ *      The sol_env_wordsz() macro determines the native word size of the
+ *      processor at compile-time. This macro supports only the architectures
+ *      defined by the SOL_ENV_ARCH type, with a compile-time error being thrown
+ *      for other processors.
+ *
+ *      Return:
+ *        - 32 if 32-bit processor detected
+ *        - 64 if 64-bit processor detected
+ */
+#if (SOL_ENV_ARCH_X86 == sol_env_arch())
+#       define sol_env_wordsz() 32
+#elif (SOL_ENV_ARCH_AMD64 == sol_env_arch())
+#       define sol_env_wordsz() 64
+#elif (SOL_ENV_ARCH_IA64 == sol_env_arch())
+#       define sol_env_wordsz() 64
+#else
+#       error "[!] sol_env_wordsz() error: unsupported architecture"
+#endif
+
+
+
+
+#endif /* (!defined __SOL_ENVIRONMENT_MODULE) */
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/inc/hint.h
+++ b/inc/hint.h
@@ -32,6 +32,11 @@
 
 
 
+#include "./env.h"
+
+
+
+
 /*
  *      sol_hot - hot code hint
  *
@@ -41,7 +46,7 @@
  *      hint is available on GCC-compatible compilation environments, and
  *      degrades gracefully to a safe no-op on other environments.
  */
-#if (defined __GNUC__) || (defined __clang__)
+#if (SOL_ENV_CC_GNUC == sol_env_cc() || SOL_ENV_CC_CLANG == sol_env_cc())
 #       define sol_hot __attribute__((hot))
 #else
 #       define sol_hot
@@ -59,7 +64,7 @@
  *      hint is available on GCC-compatible compilation environments, and
  *      degrades gracefully to a safe no-op on other environments.
  */
-#if (defined __GNUC__) || (defined __clang__)
+#if (SOL_ENV_CC_GNUC == sol_env_cc() || SOL_ENV_CC_CLANG == sol_env_cc())
 #       define sol_cold __attribute__((cold))
 #else
 #       define sol_cold
@@ -85,7 +90,7 @@
  *        - 0 if @p evaluates to false
  *        - 1 if @p evaluates to true
  */
-#if (defined __GNUC__) || (defined __clang__)
+#if (SOL_ENV_CC_GNUC == sol_env_cc() || SOL_ENV_CC_CLANG == sol_env_cc())
 #       define sol_likely(p) (__builtin_expect(!!(p), 1))
 #else
 #       define sol_likely(p) (p)
@@ -111,7 +116,7 @@
  *        - 0 if @p evaluates to false
  *        - 1 if @p evaluates to true
  */
-#if (defined __GNUC__) || (defined __clang__)
+#if (SOL_ENV_CC_GNUC == sol_env_cc() || SOL_ENV_CC_CLANG == sol_env_cc())
 #       define sol_unlikely(p) (__builtin_expect(!!(p), 0))
 #else
 #       define sol_unlikely(p) (p)
@@ -128,10 +133,11 @@
  *      This symbol expands to the inline keyword when C99 and above is used,
  *      and gracefully degrades on earlier versions.
  *
- *      If inlining is essential in C89/C90, then the only way out is to declare
- *      the inline code as a macro, optionally wrapped in a do-while(0) loop.
+ *      If inlining is essential in dialects predating C99, then the only way
+ *      out is to declare the inline code as a macro, optionally wrapped in a
+ *      do-while(0) loop.
  */
-#if (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L)
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
 #       define sol_inline inline
 #else
 #       define sol_inline
@@ -148,7 +154,7 @@
  *      This symbol expands to the restrict keyword when C99 and above is used,
  *      and gracefully degrades on earlier versions.
  */
-#if (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L)
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
 #       define sol_restrict restrict
 #else
 #       define sol_restrict

--- a/test/env.t.c
+++ b/test/env.t.c
@@ -1,0 +1,184 @@
+/******************************************************************************
+ *                           SOL LIBRARY v1.0.0+41
+ *
+ * File: sol/test/env.t.c
+ *
+ * Description:
+ *      This file is part of the internal quality checking of the Sol Library.
+ *      It implements the test suite for the environment module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+#include "../inc/env.h"
+#include "./suite.h"
+
+
+
+
+/*
+ *      cc_01() - sol_env_cc() unit test #1
+ */
+static sol_erno cc_01(void)
+{
+        #define CC_01 "sol_env_cc() is able to determine the C compiler being" \
+                      " used for compilation"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sol_env_cc() >= 0, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      stdc_01() - sol_env_stdc() unit test #1
+ */
+static sol_erno stdc_01(void)
+{
+        #define STDC_01 "sol_env_stdc() is able to determine the standard" \
+                        " C version being used for compilation"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sol_env_stdc() >= 0, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      host_01() - sol_env_host() unit test #1
+ */
+static sol_erno host_01(void)
+{
+        #define HOST_01 "sol_env_host() is able to determine the host" \
+                        " environment being used for compilation"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sol_env_host() >= 0, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      arch_01() - sol_env_arch() unit test #1
+ */
+static sol_erno arch_01(void)
+{
+        #define ARCH_01 "sol_env_arch() is able to determine the CPU" \
+                        " architecture being used for compilation"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sol_env_arch() >= 0, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      wordsz_01() - sol_env_wordsz() unit test #1
+ */
+static sol_erno wordsz_01(void)
+{
+        #define WORDSZ_01 "sol_env_arch() is able to determine the native"   \
+                          " word size of the CPU being used for compilation"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (32 == sol_env_wordsz() || 64 == sol_env_wordsz(),
+                    SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      __sol_tests_env() - declared in sol/test/suite.h
+ */
+extern sol_erno __sol_tests_env(sol_tlog *log,
+                                int *pass,
+                                int *fail,
+                                int *total)
+{
+        auto sol_tsuite __ts, *ts = &__ts;
+
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (log && pass && fail && total, SOL_ERNO_PTR);
+
+                /* initialise test suite */
+        sol_try (sol_tsuite_init2(ts, log));
+
+                /* register test cases */
+        sol_try (sol_tsuite_register(ts, &cc_01, CC_01));
+        sol_try (sol_tsuite_register(ts, &stdc_01, STDC_01));
+        sol_try (sol_tsuite_register(ts, &host_01, HOST_01));
+        sol_try (sol_tsuite_register(ts, &arch_01, ARCH_01));
+        sol_try (sol_tsuite_register(ts, &wordsz_01, WORDSZ_01));
+
+                /* execute test cases */
+        sol_try (sol_tsuite_exec(ts));
+
+                /* report test counts */
+        sol_try (sol_tsuite_pass(ts, pass));
+        sol_try (sol_tsuite_fail(ts, fail));
+        sol_try (sol_tsuite_total(ts, total));
+
+                /* wind up */
+        sol_tsuite_term(ts);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_tsuite_term(ts);
+        sol_throw();
+}
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/test/runner.c
+++ b/test/runner.c
@@ -34,38 +34,39 @@
 
 /*
  *      suite - function pointer to test suites
+ *        - log  : logging callback
+ *        - pass : passed test cases
+ *        - fail : failed test cases
+ *        - total: total test cases executed
+ *
+ *      Return:
+ *        - SOL_ERNO_NULL if no error occurs
+ *        - SOL_ERNO_TEST if a test case fails
+ *        - SOL_ERNO_PTR if an invalid pointer has been referenced
  */
-typedef sol_erno        /* error code                */
-(suite)(sol_tlog *log,  /* logging callback          */
-        int      *pass, /* passed test cases         */
-        int      *fail, /* failed test cases         */
-        int      *total /* total test cases executed */
-       );
+typedef sol_erno (suite)(sol_tlog *log,
+                         int *pass,
+                         int *fail,
+                         int *total);
+
+
 
 
 /*
- *      SUITE_COUNT - count of test suites
+ *      SUITE - enumerates test suite indices
+ *        - SUITE_ERROR: exception handling module test suite index
+ *        - SUITE_TEST : unit test module test suite index
+ *        - SUITE_HINT : compiler hints module test suite
+ *        - SUITE_ENV  : environment module test suite
+ *        - SUITE_COUNT: count of test suites
  */
-#define SUITE_COUNT 3
-
-
-/*
- *      SUITE_ERROR - index of exception handling module test suite
- */
-#define SUITE_ERROR 0
-
-
-/*
- *      SUITE_TEST - index of unit testing module test suite
- */
-#define SUITE_TEST 1
-
-
-/*
- *      SUITE_HINT - index of the compiler hints module test suite
- */
-#define SUITE_HINT 2
-
+typedef enum {
+        SUITE_ERROR,
+        SUITE_TEST,
+        SUITE_HINT,
+        SUITE_ENV,
+        SUITE_COUNT
+} SUITE;
 
 
 
@@ -105,18 +106,21 @@ typedef sol_erno        /* error code                */
 /*
  *      suite_hnd - test suite handles
  */
-static suite *suite_hnd [SUITE_COUNT];
+static suite *suite_hnd[SUITE_COUNT];
 
 
 
 
 /*
- *      stat__suite - test case statistics for each test suite
+ *      stat_suite - test case statistics for each test suite
+ *        - pass : passed test cases per suite
+ *        - fail : failed test cases per suite
+ *        - total: total test cases per suite
  */
 static struct {
-        int pass   [SUITE_COUNT]; /* passed test cases per suite */
-        int fail   [SUITE_COUNT]; /* failed test cases per suite */
-        int total  [SUITE_COUNT]; /* total test cases per suite  */
+        int pass[SUITE_COUNT];
+        int fail[SUITE_COUNT];
+        int total[SUITE_COUNT];
 } stat_suite;
 
 
@@ -124,11 +128,14 @@ static struct {
 
 /*
  *      stat_sigma - summation statistics for all test suites
+ *        - pass : sigma of passed test cases
+ *        - fail : sigma of failed test cases
+ *        - total: sigma of total test cases
  */
 static struct {
-        int pass;  /* sigma of passed test cases */
-        int fail;  /* sigma of failed test cases */
-        int total; /* sigma of total test cases  */
+        int pass;
+        int fail;
+        int total;
 } stat_sigma;
 
 
@@ -145,7 +152,7 @@ static FILE *log_hnd;
 /*
  *      log_init() - initialise test log file
  */
-static inline void
+static sol_inline void
 log_init(int  argc,  /* count of command line arguments */
          char **argv /* command line arguments          */
          )
@@ -162,7 +169,7 @@ log_init(int  argc,  /* count of command line arguments */
 /*
  *      log_term() - terminate test log file
  */
-static inline void
+static sol_inline void
 log_term(void)
 {
                 /* release log file if it's open */
@@ -177,7 +184,7 @@ log_term(void)
 /*
  *      log_tcase() - callback to log test case result
  */
-static inline void
+static sol_inline void
 log_tcase(char     const *desc, /* test case description            */
           sol_erno const erno   /* error code returned by test case */
          )
@@ -270,9 +277,10 @@ static void
 suite_init(void)
 {
                 /* register test suites */
-        suite_hnd [SUITE_ERROR] = __sol_tsuite_error;
-        suite_hnd [SUITE_TEST]  = __sol_tsuite_test;
-        suite_hnd [SUITE_HINT]  = __sol_tsuite_hint;
+        suite_hnd[SUITE_ERROR] = __sol_tsuite_error;
+        suite_hnd[SUITE_TEST] = __sol_tsuite_test;
+        suite_hnd[SUITE_HINT] = __sol_tsuite_hint;
+        suite_hnd[SUITE_ENV] = __sol_tests_env;
 }
 
 

--- a/test/suite.h
+++ b/test/suite.h
@@ -36,23 +36,19 @@
 /*
  *      __sol_tsuite_error() - test suite for exception handling module
  */
-extern sol_erno
-__sol_tsuite_error(sol_tlog *log,
-                   int      *pass,
-                   int      *fail,
-                   int      *total
-                  );
+extern sol_erno __sol_tsuite_error(sol_tlog *log,
+                                   int *pass,
+                                   int *fail,
+                                   int *total);
 
 
 /*
  *      __sol_tsuite_test() - test suite for unit testing module
  */
-extern sol_erno
-__sol_tsuite_test(sol_tlog *log,
-                  int      *pass,
-                  int      *fail,
-                  int      *total
-                 );
+extern sol_erno __sol_tsuite_test(sol_tlog *log,
+                                  int *pass,
+                                  int *fail,
+                                  int *total);
 
 
 /*
@@ -62,6 +58,19 @@ extern sol_erno __sol_tsuite_hint(sol_tlog *log,
                                   int *pass,
                                   int *fail,
                                   int *total);
+
+
+
+
+/*
+ *      __sol_tests_env() - test suite for environment module
+ */
+extern sol_erno __sol_tests_env(sol_tlog *log,
+                                int *pass,
+                                int *fail,
+                                int *total);
+
+
 
 
 #endif /* !defined __SOL_LIBRARY_TEST_SUITES */


### PR DESCRIPTION
The environment module has now been developed, and provides a portable
way to determine various characteristics of the compile-time
environment.

The following enumerations have been defined:
  * SOL_ENV_CC
  * SOL_ENV_STDC
  * SOL_ENV_HOST
  * SOL_ENV_ARCH

The following interface macros have also been defined:
  * sol_env_cc()
  * sol_env_stdc()
  * sol_env_host()
  * sol_env_arch()
  * sol_env_wordsz()

The compiler hints module has also been updated to utilise the
sol_env_cc() and sol_env_stdc() macros, along with their corresponding
enumerations SOL_ENV_CC and SOL_ENV_STDC.

This pull request closes #27.