### PR TITLE
Add pointer module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ before_install:
 #       Build target
 script:
         - make integration
+        - cat bld/test.log
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@
 
 # 	Set directory paths
 DIR_BLD  = bld
+DIR_BIN  = $(DIR_BLD)/bin
+DIR_COV  = $(DIR_BLD)/cov
 DIR_SRC  = src
 DIR_TEST = test
 
@@ -53,11 +55,11 @@ OPT_COV = -o $(DIR_BLD)
 
 
 # 	Set command inputs
-INP_SO  = $(DIR_BLD)/test.o
-INP_LD  = $(DIR_TEST)/runner.c $(DIR_TEST)/error.t.c $(DIR_TEST)/test.t.c \
-	  $(DIR_TEST)/hint.t.c $(DIR_TEST)/env.t.c
-INP_COV = $(DIR_BLD)/test.gcda $(DIR_BLD)/runner.gcda $(DIR_BLD)/error.t.gcda \
-	  $(DIR_BLD)/test.t.gcda $(DIR_BLD)/hint.t.gcda $(DIR_BLD)/env.t.gcda
+INP_SO  = $(DIR_BLD)/test.o $(DIR_BLD)/ptr.o
+INP_LD  = $(DIR_TEST)/runner.c $(DIR_TEST)/ts-error.c $(DIR_TEST)/ts-test.c \
+	  $(DIR_TEST)/ts-hint.c $(DIR_TEST)/ts-env.c $(DIR_TEST)/ts-ptr.c   \
+	  $(DIR_TEST)/ts-ptr2.c
+INP_COV = $(DIR_BLD)/test.gcda $(DIR_BLD)/ptr.gcda
 INP_RUN = $(DIR_BLD)/test.log
 
 
@@ -104,7 +106,10 @@ integration: $(OUT_LD)
 	$(CMD_RUN) $(INP_RUN)
 	mv $(DEP_COV) $(DIR_BLD)
 	$(CMD_COV) $(OPT_COV) $(INP_COV)
-	mv $(OUT_COV) $(DIR_BLD)
+	mkdir -p $(DIR_BIN)
+	mkdir -p $(DIR_COV)
+	mv $(OUT_LD) $(OUT_SO) $(DIR_BLD)/*.o $(DIR_BIN)
+	mv $(OUT_COV) $(DIR_BLD)/*.gcno $(DIR_BLD)/*.gcda $(DIR_COV)
 
 
 

--- a/inc/env.h
+++ b/inc/env.h
@@ -112,18 +112,17 @@ typedef enum __SOL_ENV_STDC {
  *      has been tested, and support for the others being assumed based on these
  *      tests.
  */
-typedef enum __SOL_ENV_HOST {
-        SOL_ENV_HOST_NONE,
-        SOL_ENV_HOST_ANDROID,
-        SOL_ENV_HOST_LINUX,
-        SOL_ENV_HOST_CYGWIN,
-        SOL_ENV_HOST_BSD,
-        SOL_ENV_HOST_HPUX,
-        SOL_ENV_HOST_AIX,
-        SOL_ENV_HOST_IOS,
-        SOL_ENV_HOST_OSX,
-        SOL_ENV_HOST_SOLARIS
-} SOL_ENV_HOST;
+#define SOL_ENV_HOST int
+#define SOL_ENV_HOST_NONE    (0)
+#define SOL_ENV_HOST_ANDROID (1)
+#define SOL_ENV_HOST_LINUX   (2)
+#define SOL_ENV_HOST_CYGWIN  (3)
+#define SOL_ENV_HOST_BSD     (4)
+#define SOL_ENV_HOST_HPUX    (5)
+#define SOL_ENV_HOST_AIX     (6)
+#define SOL_ENV_HOST_IOS     (7)
+#define SOL_ENV_HOST_OSX     (8)
+#define SOL_ENV_HOST_SOLARIS (9)
 
 
 
@@ -136,7 +135,7 @@ typedef enum __SOL_ENV_HOST {
  *
  *      The SOL_ENV_ARCH type enumerates the CPU architectures supported by the
  *      Sol Library. The constants enumerated by this type are returned by the
- *      sol_env_host() macro (defined below) in order to indicate the processor
+ *      sol_env_arch() macro (defined below) in order to indicate the processor
  *      architecture at compile-time.
  *
  *      The Sol Library currently supports the 32-bit x86 family of processors,
@@ -237,32 +236,32 @@ typedef enum __SOL_ENV_ARCH {
  *        - SOL_ENV_HOST_SOLARIS if Oracle Solaris / Open Indiana detected
  */
 #if (defined __CYGWIN__)
-#       define sol_env_host() SOL_ENV_HOST_CYGWIN
+#       define sol_env_host() (SOL_ENV_HOST_CYGWIN)
 #elif (defined __ANDROID__)
-#       define sol_env_host() SOL_ENV_HOST_ANDROID
+#       define sol_env_host() (SOL_ENV_HOST_ANDROID)
 #elif (defined __linux__)
-#       define sol_env_host() SOL_ENV_HOST_LINUX
+#       define sol_env_host() (SOL_ENV_HOST_LINUX)
 #elif (defined __hpux)
-#       define sol_env_host() SOL_ENV_HOST_HPUX
+#       define sol_env_host() (SOL_ENV_HOST_HPUX)
 #elif (defined _AIX)
-#       define sol_env_host() SOL_ENV_HOST_AIX
+#       define sol_env_host() (SOL_ENV_HOST_AIX)
 #elif (defined __sun && defined __SVR4)
-#       define sol_env_host() SOL_ENV_HOST_SOLARIS
+#       define sol_env_host() (SOL_ENV_HOST_SOLARIS)
 #elif (defined __unix__)
 #       include <sys/param.h>
 #       if (defined BSD)
-#               define sol_env_host() SOL_ENV_HOST_BSD
+#               define sol_env_host() (SOL_ENV_HOST_BSD)
 #       endif
 #elif (defined __APPLE__ && defined __MACH__)
 #       include <TargetConditionals.h>
 #       if (1 == TARGET_IPHONE_SIMULATOR || 1 == TARGET_OS_IPHONE)
-#               define sol_env_host() SOL_ENV_HOST_IOS
+#               define sol_env_host() (SOL_ENV_HOST_IOS)
 #       elif (1 == TARGET_OS_MAC)
-#               define sol_env_host() SOL_ENV_HOST_OSX
+#               define sol_env_host() (SOL_ENV_HOST_OSX)
 #       endif
 #elif (defined __STDC_HOSTED__)
 #       if (0 == __STDC_HOSTED__)
-#               define sol_env_host() SOL_ENV_HOST_NONE
+#               define sol_env_host() (SOL_ENV_HOST_NONE)
 #       endif
 #else
 #       error "[!] sol_env_host() error: unsupported host platform"

--- a/inc/error.h
+++ b/inc/error.h
@@ -119,7 +119,15 @@ typedef size_t sol_erno;
  *      test is checking has not been fulfilled. This error code is reserved by
  *      the Sol Library, and should **not** be redefined by client code.
  */
-#define SOL_ERNO_TEST ( (sol_erno)0x4 )
+#define SOL_ERNO_TEST ((sol_erno)0x4)
+
+
+
+
+/*
+ *      SOL_ERNO_HEAP - heap memory failure
+ */
+#define SOL_ERNO_HEAP ((sol_erno)0x5)
 
 
 

--- a/inc/ptr.h
+++ b/inc/ptr.h
@@ -1,0 +1,166 @@
+/******************************************************************************
+ *                           SOL LIBRARY v0.1.0+41
+ *
+ * File: sol/inc/ptr.h
+ *
+ * Description:
+ *      This file is part of the API of the Sol Library. It declares the
+ *      interface of the pointer module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* create header guard */
+#if (!defined __SOL_POINTER_MODULE)
+#define __SOL_POINTER_MODULE
+
+
+
+
+        /* include required header files */
+#include "./error.h"
+#include <stddef.h>
+
+
+
+
+/*
+ *      sol_ptr - generic pointer to any type
+ *
+ *      The sol_ptr type is an abstract type representing a generic pointer to
+ *      data type, including itself. This type can be declared only as a pointer
+ *      in order to make it explicitly obvious that a pointer is being used.
+ *
+ *      The interface functions associated with this type depend on externally
+ *      defined malloc() and free() functions in freestanding environments, and
+ *      automatically make use of the malloc() and free() functions supplied by
+ *      the standard library in hosted environments.
+ */
+typedef void sol_ptr;
+
+
+
+
+/*
+ *      SOL_PTR_NULL - generic null pointer
+ *
+ *      The SOL_PTR_NULL symbolic constant represents the generic null ponter.
+ *      Using this symbolic constant instead of the standard NULL symbol is
+ *      preferred because it removes dependence on the standard library and
+ *      preserves the Sol namespace.
+ */
+#define SOL_PTR_NULL ((sol_ptr*)0)
+
+
+
+
+/*
+ *      sol_ptr_new() - initialises a new generic pointer
+ *        - ptr: contextual pointer instance
+ *        - sz : size in bytes of pointer buffer
+ *
+ *      The sol_ptr_new() interface function creates a new instance of a generic
+ *      pointer @ptr in the heap memory with a buffer of size @sz bytes. This
+ *      function requires an externally defined malloc() function to be present
+ *      in freestanding environments; in hosted environments, it automatically
+ *      uses the malloc() supplied by the standard library.
+ *
+ *      @ptr must be a valid pointer to a **null** pointer; this restriction
+ *      helps to prevent subtle memory leaks caused by reallocating @ptr without
+ *      having first freed the heap memory already allocated to it. @sz must be
+ *      greater than zero. An appropriate exception is thrown if either of these
+ *      conditions is not met.
+ *
+ *      Return:
+ *        - SOL_ERNO_NULL if no error occurs
+ *        - SOL_ERNO_PTR if an invalid pointer has been passed
+ *        - SOL_ERNO_RANGE if an invalid size has been passed
+ *        - SOL_ERNO_HEAP if heap memory failure occurs
+ */
+extern sol_erno sol_ptr_new(sol_ptr **ptr,
+                            const size_t sz); /* NOLINT */
+
+
+
+
+/*
+ *      sol_ptr_copy() - copies an existing generic pointer
+ *        - ptr: contextual pointer instance
+ *        - src: source pointer instance
+ *        - len: length in bytes of @src to copy
+ *
+ *      The sol_ptr_copy() interface function creates a new instance of a
+ *      generic pointer @ptr in the heap memory, and copies @len bytes of data
+ *      on to it from an existing buffer pointed by @src. Just as in the case of
+ *      sol_ptr_new(), this function requires an externally defined malloc()
+ *      function to be present in freestanding environments, while automatically
+ *      selecting the malloc() supplied by the standard library in hosted
+ *      environments.
+ *
+ *      Both @ptr and @src are required to be valid pointers; just as in the
+ *      case of sol_ptr_new(), @ptr is also required to point to a null pointer
+ *      to prevent accidental memory leaks. @len is required to be greater than
+ *      zero. An appropriate exception is thrown if either of these conditions
+ *      is not met. Additionally, @len is assumed to be not greater than the
+ *      length of the buffer pointed by @src; no exception is thrown if this
+ *      condition is not met, and the resulting behaviour is undefined.
+ *
+ *      Return:
+ *        - SOL_ERNO_NULL if no error occurs
+ *        - SOL_ERNO_PTR if an invalid pointer has been passed
+ *        - SOL_ERNO_RANGE if an invalid size has been passed
+ *        - SOL_ERNO_HEAP if heap memory failure occurs
+ */
+extern sol_erno sol_ptr_copy(sol_ptr **ptr,
+                             const sol_ptr *src,
+                             const size_t len); /* NOLINT */
+
+
+
+
+/*
+ *      sol_ptr_free() - frees an existing generic pointer
+ *        - ptr: contextual pointer instance
+ *
+ *      The sol_ptr_free() interface function frees a generic pointer @ptr by
+ *      releasing the heap memory allocated to it by a previous call to either
+ *      sol_ptr_new() or sol_ptr_copy(). This function requires an externally
+ *      defined free() function to be present in freestanding environments, and
+ *      automatically uses the free() function provided by the standard library
+ *      in hosted environments. @ptr is guaranteed to be null after this
+ *      operation, thereby preventing the onset of dangling pointers.
+ *
+ *      @ptr is expected to be a valid handle to a **non-null** pointer, but in
+ *      case this condition is not met, then a safe no-op occurs.
+ */
+extern void sol_ptr_free(sol_ptr **ptr);
+
+
+
+
+#endif /* !defined __SOL_POINTER_MODULE */
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/src/ptr.c
+++ b/src/ptr.c
@@ -1,0 +1,138 @@
+/******************************************************************************
+ *                           SOL LIBRARY v1.0.0+41
+ *
+ * File: sol/src/ptr.c
+ *
+ * Description:
+ *      This file is part of the internal implementation of the Sol Library.
+ *      It implements the pointer module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* include required header files */
+#include "../inc/env.h"
+#include "../inc/ptr.h"
+
+
+
+
+        /* the implementation of the pointer module uses the standard malloc()
+         * and free() functions; in hosted environments, these are provided by
+         * the standard stdlib.h header file, and in freestanding environments
+         * by the client code (until an allocator is implemented in future) */
+#if (SOL_ENV_HOST_NONE == sol_env_host())
+        extern void *malloc(size_t);
+        extern void free(void*);
+#else
+#       include <stdlib.h>
+#endif
+
+
+
+
+/*
+ *      copy_byte() - copies a buffer on to another byte-wise
+ *        - ptr: destination buffer
+ *        - src: source buffer
+ *        - len: length in bytes to copy
+ */
+static sol_inline void copy_byte(sol_ptr **ptr,
+                                 const sol_ptr *src,
+                                 const size_t len)
+{
+                /* @ptr, @src and @len are valid, as they have already been
+                 * checked by the calling function sol_ptr_copy() */
+        register char *bdst = (char*) *ptr;
+        register char *bsrc = (char*) src;
+        register size_t itr = len;
+
+                /* copy @src to @ptr byte-by-byte for @len bytes */
+        for (; itr; itr--, *bdst++ = *bsrc++); /* NOLINT */
+}
+
+
+
+
+/*
+ *      sol_ptr_new() - declared in sol/inc/ptr.h
+ */
+extern sol_erno sol_ptr_new(sol_ptr **ptr,
+                            const size_t sz)
+{
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (ptr && !*ptr, SOL_ERNO_PTR);
+        sol_assert (sz, SOL_ERNO_RANGE);
+
+                /* allocate heap memory of size @sz to @ptr */
+        sol_assert ((*ptr = malloc(sz)), SOL_ERNO_HEAP);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      sol_ptr_copy() - declared in sol/inc/ptr.h
+ */
+extern sol_erno sol_ptr_copy(sol_ptr **ptr,
+                             const sol_ptr *src,
+                             const size_t len)
+{
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (ptr && !*ptr && src, SOL_ERNO_PTR);
+        sol_assert (len, SOL_ERNO_RANGE);
+
+                /* copy contents of @src to @ptr after allocating it */
+        sol_assert ((*ptr = malloc(len)), SOL_ERNO_HEAP);
+        copy_byte(ptr, src, len);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      sol_ptr_free() - declared in sol/inc/ptr.h
+ */
+extern void sol_ptr_free(sol_ptr **ptr)
+{
+                /* free heap memory allocated to @ptr if it's valid */
+        if (sol_likely (ptr && *ptr)) {
+                free(*ptr);
+                *ptr = SOL_PTR_NULL;
+        }
+}
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/test/runner.c
+++ b/test/runner.c
@@ -54,10 +54,12 @@ typedef sol_erno (suite)(sol_tlog *log,
 
 /*
  *      SUITE - enumerates test suite indices
- *        - SUITE_ERROR: exception handling module test suite index
- *        - SUITE_TEST : unit test module test suite index
- *        - SUITE_HINT : compiler hints module test suite
- *        - SUITE_ENV  : environment module test suite
+ *        - SUITE_ERROR: exception handling module test suite
+ *        - SUITE_TEST : unit test module test suite
+ *        - SUITE_HINT : compiler hints module test
+ *        - SUITE_ENV  : environment module test
+ *        - SUITE_PTR  : pointer module test suite
+ *        - SUITE_PTR2 : freestanding pointer module test suite
  *        - SUITE_COUNT: count of test suites
  */
 typedef enum {
@@ -65,6 +67,8 @@ typedef enum {
         SUITE_TEST,
         SUITE_HINT,
         SUITE_ENV,
+        SUITE_PTR,
+        SUITE_PTR2,
         SUITE_COUNT
 } SUITE;
 
@@ -281,6 +285,8 @@ suite_init(void)
         suite_hnd[SUITE_TEST] = __sol_tsuite_test;
         suite_hnd[SUITE_HINT] = __sol_tsuite_hint;
         suite_hnd[SUITE_ENV] = __sol_tests_env;
+        suite_hnd[SUITE_PTR] = __sol_tests_ptr;
+        suite_hnd[SUITE_PTR2] = __sol_tests_ptr2;
 }
 
 

--- a/test/suite.h
+++ b/test/suite.h
@@ -26,11 +26,17 @@
 
 
 
+        /* add header guard */
 #if !defined __SOL_LIBRARY_TEST_SUITES
 #define __SOL_LIBRARY_TEST_SUITES
 
 
+
+
+        /* include required header files */
 #include "../inc/test.h"
+
+
 
 
 /*
@@ -42,6 +48,8 @@ extern sol_erno __sol_tsuite_error(sol_tlog *log,
                                    int *total);
 
 
+
+
 /*
  *      __sol_tsuite_test() - test suite for unit testing module
  */
@@ -49,6 +57,8 @@ extern sol_erno __sol_tsuite_test(sol_tlog *log,
                                   int *pass,
                                   int *fail,
                                   int *total);
+
+
 
 
 /*
@@ -69,6 +79,32 @@ extern sol_erno __sol_tests_env(sol_tlog *log,
                                 int *pass,
                                 int *fail,
                                 int *total);
+
+
+
+
+/*
+ *      __sol_tests_ptr() - test suite for the pointer module
+ */
+extern sol_erno __sol_tests_ptr(sol_tlog *log,
+                                int *pass,
+                                int *fail,
+                                int *total);
+
+
+
+
+/*
+ *      __sol_tests_ptr2() - mock freestanding tests for the pointer module
+ */
+#if (SOL_ENV_HOSTED_NONE != sol_env_host())
+        extern sol_erno __sol_tests_ptr2(sol_tlog *log,
+                                         int      *pass,
+                                         int      *fail,
+                                         int      *total);
+#else
+#       define __sol_tests_ptr2()
+#endif
 
 
 

--- a/test/ts-env.c
+++ b/test/ts-env.c
@@ -1,7 +1,7 @@
 /******************************************************************************
  *                           SOL LIBRARY v1.0.0+41
  *
- * File: sol/test/env.t.c
+ * File: sol/test/ts-env.c
  *
  * Description:
  *      This file is part of the internal quality checking of the Sol Library.

--- a/test/ts-error.c
+++ b/test/ts-error.c
@@ -1,7 +1,7 @@
 /******************************************************************************
  *                           SOL LIBRARY v1.0.0+41
  *
- * File: sol/test/error.t.c
+ * File: sol/test/ts-error.c
  *
  * Description:
  *      This file is part of the internal quality checking of the Sol Library.

--- a/test/ts-hint.c
+++ b/test/ts-hint.c
@@ -1,7 +1,7 @@
 /******************************************************************************
  *                           SOL LIBRARY v1.0.0+41
  *
- * File: sol/test/hint.t.c
+ * File: sol/test/ts-hint.c
  *
  * Description:
  *      This file is part of the internal quality checking of the Sol Library.

--- a/test/ts-ptr.c
+++ b/test/ts-ptr.c
@@ -1,0 +1,401 @@
+/******************************************************************************
+ *                           SOL LIBRARY v1.0.0+41
+ *
+ * File: sol/test/ts-ptr.c
+ *
+ * Description:
+ *      This file is part of the internal quality checking of the Sol Library.
+ *      It implements the test suite for the pointer module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* include required header files */
+#include "../inc/ptr.h"
+#include "./suite.h"
+
+
+
+
+/*
+ *      new_01() - sol_ptr_new() unit test #1
+ */
+static sol_erno new_01(void)
+{
+        #define NEW_01 "sol_ptr_new() throws SOL_ERNO_PTR when passed a null" \
+                       " pointer for @ptr"
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_ptr_new(SOL_PTR_NULL, sizeof (int)));
+
+SOL_CATCH:
+                /* check test condition */
+        return SOL_ERNO_PTR == sol_erno_now()
+               ? SOL_ERNO_NULL
+               : SOL_ERNO_TEST;
+}
+
+
+
+
+/*
+ *      new_02() - sol_ptr_new() unit test #2
+ */
+static sol_erno new_02(void)
+{
+        #define NEW_02 "sol_ptr_new() throws SOL_ERNO_PTR when passed a"   \
+                       " pointer for @ptr that has already been allocated"
+        auto sol_ptr *ptr = SOL_PTR_NULL;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_assert (!sol_ptr_new(&ptr, sizeof (int)), SOL_ERNO_TEST);
+        sol_try (sol_ptr_new(&ptr, sizeof (int)));
+
+                /* wind up */
+        sol_ptr_free(&ptr);
+
+SOL_CATCH:
+                /* wind up */
+        sol_ptr_free(&ptr);
+
+                /* check test condition */
+        return SOL_ERNO_PTR == sol_erno_now()
+               ? SOL_ERNO_NULL
+               : SOL_ERNO_TEST;
+}
+
+
+
+
+/*
+ *      new_03() - sol_ptr_new() unit test #3
+ */
+static sol_erno new_03(void)
+{
+        #define NEW_03 "sol_ptr_new() throws SOL_ERNO_RANGE when passed 0" \
+                       " for @sz"
+        auto sol_ptr *ptr = SOL_PTR_NULL;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_ptr_new(&ptr, 0));
+
+                /* wind up */
+        sol_ptr_free(&ptr);
+
+SOL_CATCH:
+                /* wind up */
+        sol_ptr_free(&ptr);
+
+                /* check test condition */
+        return SOL_ERNO_RANGE == sol_erno_now()
+               ? SOL_ERNO_NULL
+               : SOL_ERNO_TEST;
+}
+
+
+
+
+/*
+ *      new_04() - sol_ptr_new() unit test #4
+ */
+static sol_erno new_04(void)
+{
+        #define NEW_04 "sol_ptr_new() successfully allocates heap memory"
+        auto int *ptr = SOL_PTR_NULL;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_ptr_new((sol_ptr**)&ptr, sizeof (*ptr)));
+        *ptr = -612;
+
+                /* check test condition */
+        sol_assert (*ptr == -612, SOL_ERNO_TEST);
+
+                /* wind up */
+        sol_ptr_free((sol_ptr**)&ptr);
+
+SOL_CATCH:
+                /* wind up */
+        sol_ptr_free((sol_ptr**)&ptr);
+
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      copy_01() - sol_ptr_copy() unit test #1
+ */
+static sol_erno copy_01(void)
+{
+        #define COPY_01 "sol_ptr_copy() throws SOL_ERNO_PTR when passed a " \
+                        " null pointer for @ptr"
+        auto int *src = SOL_PTR_NULL;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_assert (!sol_ptr_new((sol_ptr*)&src, sizeof (int)), SOL_ERNO_TEST);
+        sol_try (sol_ptr_copy(SOL_PTR_NULL, (sol_ptr*)src, sizeof (int)));
+
+                /* wind up */
+        sol_ptr_free((sol_ptr**)&src);
+
+SOL_CATCH:
+                /* wind up */
+        sol_ptr_free((sol_ptr**)&src);
+
+                /* check test condition */
+        return SOL_ERNO_PTR == sol_erno_now()
+               ? SOL_ERNO_NULL
+               : SOL_ERNO_TEST;
+}
+
+
+
+
+/*
+ *      copy_02() - sol_ptr_copy() unit test #2
+ */
+static sol_erno copy_02(void)
+{
+        #define COPY_02 "sol_ptr_copy() throws SOL_ERNO_PTR when passed a"   \
+                        " pointer for @ptr that has already been allocated"
+        auto sol_ptr *ptr = SOL_PTR_NULL;
+        auto int *src = SOL_PTR_NULL;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_assert (!sol_ptr_new((sol_ptr*)&src, sizeof (int)), SOL_ERNO_TEST);
+        sol_assert (!sol_ptr_new(&ptr, sizeof (int)), SOL_ERNO_TEST);
+        sol_try (sol_ptr_copy(ptr, (sol_ptr*)src, sizeof (int)));
+
+                /* wind up */
+        sol_ptr_free(&ptr);
+        sol_ptr_free((sol_ptr**)&src);
+
+SOL_CATCH:
+                /* wind up */
+        sol_ptr_free(&ptr);
+        sol_ptr_free((sol_ptr**)&src);
+
+                /* check test condition */
+        return SOL_ERNO_PTR == sol_erno_now()
+               ? SOL_ERNO_NULL
+               : SOL_ERNO_TEST;
+}
+
+
+
+
+/*
+ *      copy_03() - sol_ptr_copy() unit test #3
+ */
+static sol_erno copy_03(void)
+{
+        #define COPY_03 "sol_ptr_copy() throws SOL_ERNO_RANGE when passed 0" \
+                        " for @sz"
+        auto sol_ptr *ptr = SOL_PTR_NULL;
+        auto int *src = SOL_PTR_NULL;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_assert (!sol_ptr_new((sol_ptr**)&src, sizeof (int)), SOL_ERNO_TEST);
+        sol_try (sol_ptr_copy(&ptr, (sol_ptr*)src, 0));
+
+                /* wind up */
+        sol_ptr_free(&ptr);
+        sol_ptr_free((sol_ptr**)&src);
+
+SOL_CATCH:
+                /* wind up */
+        sol_ptr_free(&ptr);
+        sol_ptr_free((sol_ptr**)&src);
+
+                /* check test condition */
+        return SOL_ERNO_RANGE == sol_erno_now()
+               ? SOL_ERNO_NULL
+               : SOL_ERNO_TEST;
+}
+
+
+
+
+/*
+ *      copy_04() - sol_ptr_copy() unit test #4
+ */
+static sol_erno copy_04(void)
+{
+        #define COPY_04 "sol_ptr_copy() throws SOL_ERNO_PTR when passed a" \
+                        " null pointer for @src"
+        auto sol_ptr *ptr = SOL_PTR_NULL;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_ptr_copy(&ptr, SOL_PTR_NULL, sizeof (int)));
+
+                /* wind up */
+        sol_ptr_free(&ptr);
+
+SOL_CATCH:
+                /* wind up */
+        sol_ptr_free(&ptr);
+
+                /* check test condition */
+        return SOL_ERNO_PTR == sol_erno_now()
+               ? SOL_ERNO_NULL
+               : SOL_ERNO_TEST;
+}
+
+
+
+
+static sol_erno copy_05(void)
+{
+        #define COPY_05 "sol_ptr_copy() correctly copies the contents of @src" \
+                        " on to @ptr"
+        auto int *ptr = SOL_PTR_NULL;
+        auto int *src = SOL_PTR_NULL;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_ptr_new((sol_ptr**)&src, sizeof (*src)));
+        *src = -555;
+        sol_try (sol_ptr_copy((sol_ptr**)&ptr, src, sizeof (*ptr)));
+
+                /* check test condition */
+        sol_assert (*ptr == -555, SOL_ERNO_TEST);
+
+                /* wind up */
+        sol_ptr_free((sol_ptr**)&ptr);
+        sol_ptr_free((sol_ptr**)&src);
+
+SOL_CATCH:
+                /* wind up */
+        sol_ptr_free((sol_ptr**)&ptr);
+        sol_ptr_free((sol_ptr**)&src);
+
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      free_01() - sol_ptr_free() unit test #1
+ */
+static sol_erno free_01(void)
+{
+        #define FREE_01 "sol_ptr_free() executes even if passed an invalid" \
+                        " pointer for @ptr"
+
+                /* set up test scenario */
+        sol_ptr_free(SOL_PTR_NULL);
+        return SOL_ERNO_NULL;
+}
+
+
+
+
+/*
+ *      free_02() - sol_ptr_free() unit test #2
+ */
+static sol_erno free_02(void)
+{
+        #define FREE_02 "sol_ptr_free() releases the heap memory allocated to" \
+                        " @ptr"
+        auto int *ptr = SOL_PTR_NULL;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_ptr_new((sol_ptr**) &ptr, sizeof (*ptr)));
+        *ptr = 5;
+        sol_ptr_free((sol_ptr**) &ptr);
+
+                /* check test condition */
+        sol_assert (!ptr, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+/*
+ *      __sol_tests_ptr() - declared in sol/test/suite.h
+ */
+extern sol_erno __sol_tests_ptr(sol_tlog *log,
+                                int *pass,
+                                int *fail,
+                                int *total)
+{
+        auto sol_tsuite __ts, *ts = &__ts;
+
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (log && pass && fail && total, SOL_ERNO_PTR);
+
+                /* initialise test suite */
+        sol_try (sol_tsuite_init2(ts, log));
+
+                /* register test cases */
+        sol_try (sol_tsuite_register(ts, &new_01, NEW_01));
+        sol_try (sol_tsuite_register(ts, &new_02, NEW_02));
+        sol_try (sol_tsuite_register(ts, &new_03, NEW_03));
+        sol_try (sol_tsuite_register(ts, &new_04, NEW_04));
+        sol_try (sol_tsuite_register(ts, &copy_01, COPY_01));
+        sol_try (sol_tsuite_register(ts, &copy_02, COPY_02));
+        sol_try (sol_tsuite_register(ts, &copy_03, COPY_03));
+        sol_try (sol_tsuite_register(ts, &copy_04, COPY_04));
+        sol_try (sol_tsuite_register(ts, &copy_05, COPY_05));
+        sol_try (sol_tsuite_register(ts, &free_01, FREE_01));
+        sol_try (sol_tsuite_register(ts, &free_02, FREE_02));
+
+                /* execute test cases */
+        sol_try (sol_tsuite_exec(ts));
+
+                /* report test counts */
+        sol_try (sol_tsuite_pass(ts, pass));
+        sol_try (sol_tsuite_fail(ts, fail));
+        sol_try (sol_tsuite_total(ts, total));
+
+                /* wind up */
+        sol_tsuite_term(ts);
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_tsuite_term(ts);
+        sol_throw();
+}
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/test/ts-ptr2.c
+++ b/test/ts-ptr2.c
@@ -1,0 +1,91 @@
+/******************************************************************************
+ *                           SOL LIBRARY v1.0.0+41
+ *
+ * File: sol/test/ts-ptr2.c
+ *
+ * Description:
+ *      This file is part of the internal quality checking of the Sol Library.
+ *      It implements the test suite for the pointer module while mocking a
+ *      freestanding environment on a hosted environment.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* include required header files */
+#include "./suite.h"
+
+
+
+
+        /* proceed only if we're on a hosted environment */
+#if (SOL_ENV_HOSTED_NONE != sol_env_host())
+
+
+
+
+        /* mock a freestanding environment on the current hosted environment;
+         * include the stdlib.h header file to mock the malloc() and free()
+         * functions for the mocked freestanding environment */
+#define __SOL_ENV_HOST_BKP sol_env_host()
+#undef sol_env_host
+#define sol_env_host() SOL_ENV_HOSTED_NONE
+#include <stdlib.h>
+
+
+
+
+/*
+ *      __sol_tests_ptr2() - declared in sol/test/suite.h
+ */
+extern sol_erno __sol_tests_ptr2(sol_tlog *log,
+                                 int      *pass,
+                                 int      *fail,
+                                 int      *total)
+{
+SOL_TRY:
+                /* run pointer module test cases in the simulated freestanding
+                 * environment */
+        sol_try (__sol_tests_ptr(log, pass, fail, total));
+
+SOL_CATCH:
+                /* throw current exception, if any */
+        sol_throw();
+}
+
+
+
+
+        /* reset to original hosted environment */
+#undef sol_env_host
+#define sol_env_host() __SOL_ENV_HOST_BKP
+#undef __SOL_ENV_HOST_BKP
+
+
+
+
+#endif /* SOL_ENV_HOSTED_NONE != sol_env_host() */
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/test/ts-test.c
+++ b/test/ts-test.c
@@ -1,7 +1,7 @@
 /******************************************************************************
  *                           SOL LIBRARY v1.0.0+41
  *
- * File: sol/test/test.t.c
+ * File: sol/test/ts-test.c
  *
  * Description:
  *      This file is part of the internal quality checking of the Sol Library.


### PR DESCRIPTION
The pointer module has been implemented with the sol_ptr type
representing a generic pointer to any data type along with its
corresponding SOL_PTR_NULL symbolic constant. The associated interface
functions sol_ptr_new(), sol_ptr_copy(), and sol_ptr_free() have also
been implemented, mirroring the standard malloc(), memcpy() and free()
functions, but with better checks.

The interface functions require externally defined malloc() and free()
functions to be provided in freestanding environments; in a future
version, the Sol Library might include its own custom heap memory
allocator.

Additionally, the SOL_ENV_HOST constants have been redefined in order to
fix the compilation errors encountered when trying to use them as-is in
the pointer module.

Unit tests have been included for both hosted and freestanding
environments, the latter being simulated in hosted environments.

This pull request closes #33.