### PR TITLE
Incorporate finally block

### DIFF
--- a/src/ptr.c
+++ b/src/ptr.c
@@ -85,8 +85,9 @@ SOL_TRY:
         sol_assert ((*ptr = malloc(sz)), SOL_ERNO_HEAP);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -109,8 +110,9 @@ SOL_TRY:
         copy_byte(ptr, src, len);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 

--- a/src/test.c
+++ b/src/test.c
@@ -74,8 +74,9 @@ SOL_TRY:
         tsuite_init (tsuite, 0);
 
 SOL_CATCH:
-                /* throw exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -98,8 +99,9 @@ SOL_TRY:
         tsuite_init (tsuite, tlog);
 
 SOL_CATCH:
-                /* throw exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -158,8 +160,9 @@ SOL_TRY:
         tsuite->total++;
 
 SOL_CATCH:
-                /* throw exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -181,8 +184,9 @@ SOL_TRY:
         *pass = tsuite->total - tsuite->fail;
 
 SOL_CATCH:
-                /* throw exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -204,8 +208,9 @@ SOL_TRY:
         *fail = tsuite->fail;
 
 SOL_CATCH:
-                /* throw exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -227,8 +232,9 @@ SOL_TRY:
         *total = tsuite->total;
 
 SOL_CATCH:
-                /* throw exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -264,8 +270,9 @@ SOL_TRY:
         }
 
 SOL_CATCH:
-                /* throw exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 

--- a/test/ts-env.c
+++ b/test/ts-env.c
@@ -45,8 +45,9 @@ SOL_TRY:
         sol_assert (sol_env_cc() >= 0, SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -65,8 +66,9 @@ SOL_TRY:
         sol_assert (sol_env_stdc() >= 0, SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -85,8 +87,9 @@ SOL_TRY:
         sol_assert (sol_env_host() >= 0, SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -105,8 +108,9 @@ SOL_TRY:
         sol_assert (sol_env_arch() >= 0, SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -126,8 +130,9 @@ SOL_TRY:
                     SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -165,13 +170,11 @@ SOL_TRY:
         sol_try (sol_tsuite_fail(ts, fail));
         sol_try (sol_tsuite_total(ts, total));
 
+SOL_CATCH:
+SOL_FINALLY:
                 /* wind up */
         sol_tsuite_term(ts);
-
-SOL_CATCH:
-                /* throw current exception, if any */
-        sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 

--- a/test/ts-error.c
+++ b/test/ts-error.c
@@ -26,6 +26,7 @@
 
 
 
+        /* include required header files */
 #include "../inc/test.h"
 #include "./suite.h"
 
@@ -33,209 +34,175 @@
 
 
 /*
- *      DESC_ASSERT_01 - description for sol_assert() unit test #1
+ *      mock_assertpass() - simulates success of sol_assert()
  */
-#define DESC_ASSERT_01 "sol_assert() must not throw an error for a" \
-                       " predicate that evaluates to true"
-
-
-
-
-/*
- *      DESC_ASSERT_02 - description for sol_assert() unit test #2
- */
-#define DESC_ASSERT_02 "sol_assert() must throw an error for a" \
-                       " predicate that evaluates to false"
-
-
-
-
-/*
- *      DESC_TRY_01 - description for sol_try() unit test #1
- */
-#define DESC_TRY_01 "sol_try() must not throw an error for a function that" \
-                    " returns a SOL_ERNO_NULL error code"
-
-
-
-
-/*
- *      DESC_TRY_02 - description for sol_try() unit test #2
- */
-#define DESC_TRY_02 "sol_try() must throw an error for a function that" \
-                    " returns an error code other than SOL_ERNO_NULL"
-
-
-
-
-/*
- *      DESC_NOW_01 - description for sol_erno_now() unit test #1
- */
-#define DESC_NOW_01 "sol_erno_now() must return the current error code that" \
-                    " was thrown by the last calling function"
-
-
-
-
-/*
- *      assert_pass() - simulates success of sol_assert()
- */
-static sol_erno
-assert_pass(void)
+static sol_erno mock_assertpass(void)
 {
 SOL_TRY:
                 /* this condition will always pass */
         sol_assert (1 == 1, SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* control will never reach here */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      assert_fail() - simulates failure of sol_assert()
+ *      mock_assertfail() - simulates failure of sol_assert()
  */
-static sol_erno
-assert_fail(void)
+static sol_erno mock_assertfail(void)
 {
 SOL_TRY:
                 /* this condition will always fail */
         sol_assert (1 != 1, SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* control will always reach here */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      try_pass() - simulates success of sol_try()
+ *      mock_trypass() - simulates success of sol_try()
  */
-static sol_erno
-try_pass(void)
+static sol_erno mock_trypass(void)
 {
 SOL_TRY:
-                /* assert_pass() is guaranteed to succeed */
-        sol_try (assert_pass ());
+                /* mock_assertpass() is guaranteed to succeed */
+        sol_try (mock_assertpass ());
 
 SOL_CATCH:
-                /* control will never reach here */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      try_fail() - simulates failure of sol_try()
+ *      mock_tryfail() - simulates failure of sol_try()
  */
-static sol_erno
-try_fail(void)
+static sol_erno mock_tryfail(void)
 {
 SOL_TRY:
-                /* assert_fail() is guaranteed to fail */
-        sol_try (assert_fail ());
+                /* mock_assertfail() is guaranteed to fail */
+        sol_try (mock_assertfail ());
 
 SOL_CATCH:
-                /* control will always reach here */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      test_assert_01() - sol_assert() unit test #1
+ *      test_assert1() - sol_assert() unit test #1
  */
-static sol_erno
-test_assert_01(void)
+static sol_erno test_assert1(void)
 {
+        #define DESC_ASSERT1 "sol_assert() must not throw an error for a" \
+                             " predicate that evaluates to true"
 SOL_TRY:
-                /* check test condition described by DESC_ASSERT_01 */
-        sol_assert (!assert_pass (), SOL_ERNO_TEST);
+                /* check test condition */
+        sol_assert (!mock_assertpass(), SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* catch exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      test_assert_02() - sol_assert() unit test #2
+ *      test_assert2() - sol_assert() unit test #2
  */
-static sol_erno
-test_assert_02(void)
+static sol_erno test_assert2(void)
 {
+        #define DESC_ASSERT2 "sol_assert() must throw an error for a" \
+                             " predicate that evaluates to false"
 SOL_TRY:
-                /* check test condition described by DESC_ASSERT_02 */
-        sol_assert (assert_fail (), SOL_ERNO_TEST);
+                /* check test condition */
+        sol_assert (mock_assertfail(), SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* catch exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      test_try_01() - sol_try() unit test #1
+ *      test_try1() - sol_try() unit test #1
  */
-static sol_erno
-test_try_01(void)
+static sol_erno test_try1(void)
 {
+        #define DESC_TRY1 "sol_try() must not throw an error for a function" \
+                          " that returns a SOL_ERNO_NULL error code"
 SOL_TRY:
-                /* check test condition described by DESC_TRY_01 */
-        sol_assert (!try_pass (), SOL_ERNO_TEST);
+                /* check test condition */
+        sol_assert (!mock_trypass(), SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* catch exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      test_try_02() - sol_try() unit test #2
+ *      test_try2() - sol_try() unit test #2
  */
-static sol_erno
-test_try_02(void)
+static sol_erno test_try2(void)
 {
+        #define DESC_TRY2 "sol_try() must throw an error for a function that" \
+                          " returns an error code other than SOL_ERNO_NULL"
 SOL_TRY:
-                /* check test condition described by DESC_TRY_01 */
-        sol_assert (try_fail (), SOL_ERNO_TEST);
+                /* check test condition */
+        sol_assert (mock_tryfail(), SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* catch exceptions */
-        sol_throw ();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      test_now_01() - sol_erno_now() unit test #1
+ *      test_get1() - sol_erno_get() unit test #1
  */
-static sol_erno
-test_now_01(void)
+static sol_erno test_get1(void)
 {
+        #define DESC_GET1 "sol_erno_get() must return the current error code"
 SOL_TRY:
-                /* assert_fail () is guaranteed to fail with SOL_ERNO_TEST */
-        sol_try (assert_fail ());
+                /* set up test scenario */
+        sol_try (mock_assertfail());
 
 SOL_CATCH:
-                /* check test condition described by DESC_NOW_01 */
-        return SOL_ERNO_TEST == sol_erno_now ()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+                /* check test condition */
+        sol_erno_set(SOL_ERNO_TEST == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -244,12 +211,10 @@ SOL_CATCH:
 /*
  *      __sol_tsuite_error() - declared in sol/test/suite.h
  */
-extern sol_erno
-__sol_tsuite_error(sol_tlog *log,
-                   int      *pass,
-                   int      *fail,
-                   int      *total
-                  )
+extern sol_erno __sol_tsuite_error(sol_tlog *log,
+                                   int *pass,
+                                   int *fail,
+                                   int *total)
 {
         auto sol_tsuite __ts, *ts = &__ts;
 
@@ -258,30 +223,28 @@ SOL_TRY:
         sol_assert (log && pass && fail && total, SOL_ERNO_PTR);
 
                 /* initialise test suite */
-        sol_try (sol_tsuite_init2 (ts, log));
+        sol_try (sol_tsuite_init2(ts, log));
 
                 /* register test cases */
-        sol_try (sol_tsuite_register (ts, test_assert_01, DESC_ASSERT_01));
-        sol_try (sol_tsuite_register (ts, test_assert_02, DESC_ASSERT_02));
-        sol_try (sol_tsuite_register (ts, test_try_01,    DESC_TRY_01));
-        sol_try (sol_tsuite_register (ts, test_try_02,    DESC_TRY_02));
-        sol_try (sol_tsuite_register (ts, test_now_01,    DESC_NOW_01));
+        sol_try (sol_tsuite_register(ts, test_assert1, DESC_ASSERT1));
+        sol_try (sol_tsuite_register(ts, test_assert2, DESC_ASSERT2));
+        sol_try (sol_tsuite_register(ts, test_try1, DESC_TRY1));
+        sol_try (sol_tsuite_register(ts, test_try2, DESC_TRY2));
+        sol_try (sol_tsuite_register(ts, test_get1, DESC_GET1));
 
                 /* execute test cases */
-        sol_try (sol_tsuite_exec (ts));
+        sol_try (sol_tsuite_exec(ts));
 
                 /* return test counts */
-        sol_try (sol_tsuite_pass  (ts, pass));
-        sol_try (sol_tsuite_fail  (ts, fail));
-        sol_try (sol_tsuite_total (ts, total));
-
-                /* wind up */
-        sol_tsuite_term (ts);
+        sol_try (sol_tsuite_pass(ts, pass));
+        sol_try (sol_tsuite_fail(ts, fail));
+        sol_try (sol_tsuite_total(ts, total));
 
 SOL_CATCH:
-                /* wind up and throw current exception */
-        sol_tsuite_term (ts);
-        sol_throw       ();
+SOL_FINALLY:
+                /* wind up */
+        sol_tsuite_term(ts);
+        return sol_erno_get();
 }
 
 

--- a/test/ts-hint.c
+++ b/test/ts-hint.c
@@ -26,6 +26,7 @@
 
 
 
+        /* include required header files */
 #include "./suite.h"
 #include "../inc/hint.h"
 
@@ -149,7 +150,9 @@ SOL_TRY:
         sol_assert (sol_likely (1), SOL_ERNO_TEST);
 
 SOL_CATCH:
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 #endif /* (defined __GNUC__ || defined __clang__) */
 
@@ -171,7 +174,9 @@ SOL_TRY:
         sol_assert (!sol_likely (0), SOL_ERNO_TEST);
 
 SOL_CATCH:
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 #endif /* (defined __GNUC__ || defined __clang__) */
 
@@ -194,14 +199,13 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (sol_likely (1), SOL_ERNO_TEST);
-        gcc_on();
-        clang_on();
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         gcc_on();
         clang_on();
-        sol_throw();
+        return sol_erno_get();
 }
 
 
@@ -223,14 +227,13 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (!sol_likely (0), SOL_ERNO_TEST);
-        gcc_on();
-        clang_on();
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         gcc_on();
         clang_on();
-        sol_throw();
+        return sol_erno_get();
 }
 
 
@@ -251,7 +254,9 @@ SOL_TRY:
         sol_assert (sol_unlikely (1), SOL_ERNO_TEST);
 
 SOL_CATCH:
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 #endif /* (defined __GNUC__ || defined __clang__) */
 
@@ -273,7 +278,9 @@ SOL_TRY:
         sol_assert (!sol_unlikely (0), SOL_ERNO_TEST);
 
 SOL_CATCH:
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 #endif /* (defined __GNUC__ || defined __clang__) */
 
@@ -296,14 +303,13 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (sol_unlikely (1), SOL_ERNO_TEST);
-        gcc_on();
-        clang_on();
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         gcc_on();
         clang_on();
-        sol_throw();
+        return sol_erno_get();
 }
 
 
@@ -325,14 +331,13 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (!sol_unlikely (0), SOL_ERNO_TEST);
-        gcc_on();
-        clang_on();
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         gcc_on();
         clang_on();
-        sol_throw();
+        return sol_erno_get();
 }
 
 
@@ -351,8 +356,9 @@ SOL_TRY:
         sol_assert (mock_hot(), SOL_ERNO_TEST);
 
 SOL_CATCH:
+SOL_FINALLY:
                 /* throw current exception, if any */
-        sol_throw();
+        return sol_erno_get();
 }
 
 
@@ -373,14 +379,13 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (mock_hot(), SOL_ERNO_TEST);
-        gcc_on();
-        clang_on();
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         gcc_on();
         clang_on();
-        sol_throw();
+        return sol_erno_get();
 }
 
 
@@ -399,8 +404,9 @@ SOL_TRY:
         sol_assert (mock_cold(), SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -421,14 +427,13 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (mock_cold(), SOL_ERNO_TEST);
-        gcc_on();
-        clang_on();
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         gcc_on();
         clang_on();
-        sol_throw();
+        return sol_erno_get();
 }
 
 
@@ -447,8 +452,9 @@ SOL_TRY:
         sol_assert (mock_inline(), SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -469,14 +475,13 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (mock_inline(), SOL_ERNO_TEST);
-        gcc_on();
-        clang_on();
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         gcc_on();
         clang_on();
-        sol_throw();
+        return sol_erno_get();
 }
 
 
@@ -495,8 +500,9 @@ SOL_TRY:
         sol_assert (mock_restrict(&tmp), SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -546,12 +552,12 @@ SOL_TRY:
         sol_try (sol_tsuite_pass(ts, pass));
         sol_try (sol_tsuite_fail(ts, fail));
         sol_try (sol_tsuite_total(ts, total));
-        sol_tsuite_term(ts);
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 

--- a/test/ts-ptr.c
+++ b/test/ts-ptr.c
@@ -34,12 +34,12 @@
 
 
 /*
- *      new_01() - sol_ptr_new() unit test #1
+ *      test_new1() - sol_ptr_new() unit test #1
  */
-static sol_erno new_01(void)
+static sol_erno test_new1(void)
 {
-        #define NEW_01 "sol_ptr_new() throws SOL_ERNO_PTR when passed a null" \
-                       " pointer for @ptr"
+        #define DESC_NEW1 "sol_ptr_new() throws SOL_ERNO_PTR when passed a" \
+                          " null pointer for @ptr"
 
 SOL_TRY:
                 /* set up test scenario */
@@ -47,21 +47,25 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      new_02() - sol_ptr_new() unit test #2
+ *      test_new2() - sol_ptr_new() unit test #2
  */
-static sol_erno new_02(void)
+static sol_erno test_new2(void)
 {
-        #define NEW_02 "sol_ptr_new() throws SOL_ERNO_PTR when passed a"   \
-                       " pointer for @ptr that has already been allocated"
+        #define DESC_NEW2 "sol_ptr_new() throws SOL_ERNO_PTR when passed a" \
+                          " pointer for @ptr that has already been allocated"
         auto sol_ptr *ptr = SOL_PTR_NULL;
 
 SOL_TRY:
@@ -69,57 +73,55 @@ SOL_TRY:
         sol_assert (!sol_ptr_new(&ptr, sizeof (int)), SOL_ERNO_TEST);
         sol_try (sol_ptr_new(&ptr, sizeof (int)));
 
-                /* wind up */
-        sol_ptr_free(&ptr);
-
 SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
                 /* wind up */
         sol_ptr_free(&ptr);
-
-                /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      new_03() - sol_ptr_new() unit test #3
+ *      test_new3() - sol_ptr_new() unit test #3
  */
-static sol_erno new_03(void)
+static sol_erno test_new3(void)
 {
-        #define NEW_03 "sol_ptr_new() throws SOL_ERNO_RANGE when passed 0" \
-                       " for @sz"
+        #define DESC_NEW3 "sol_ptr_new() throws SOL_ERNO_RANGE when passed 0" \
+                          " for @sz"
         auto sol_ptr *ptr = SOL_PTR_NULL;
 
 SOL_TRY:
                 /* set up test scenario */
         sol_try (sol_ptr_new(&ptr, 0));
 
-                /* wind up */
-        sol_ptr_free(&ptr);
-
 SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(SOL_ERNO_RANGE == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
                 /* wind up */
         sol_ptr_free(&ptr);
-
-                /* check test condition */
-        return SOL_ERNO_RANGE == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      new_04() - sol_ptr_new() unit test #4
+ *      test_new4() - sol_ptr_new() unit test #4
  */
-static sol_erno new_04(void)
+static sol_erno test_new4(void)
 {
-        #define NEW_04 "sol_ptr_new() successfully allocates heap memory"
+        #define DESC_NEW4 "sol_ptr_new() successfully allocates heap memory"
         auto int *ptr = SOL_PTR_NULL;
 
 SOL_TRY:
@@ -130,27 +132,23 @@ SOL_TRY:
                 /* check test condition */
         sol_assert (*ptr == -612, SOL_ERNO_TEST);
 
-                /* wind up */
-        sol_ptr_free((sol_ptr**)&ptr);
-
 SOL_CATCH:
+SOL_FINALLY:
                 /* wind up */
         sol_ptr_free((sol_ptr**)&ptr);
-
-                /* throw current exception, if any */
-        sol_throw();
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      copy_01() - sol_ptr_copy() unit test #1
+ *      test_copy1() - sol_ptr_copy() unit test #1
  */
-static sol_erno copy_01(void)
+static sol_erno test_copy1(void)
 {
-        #define COPY_01 "sol_ptr_copy() throws SOL_ERNO_PTR when passed a " \
-                        " null pointer for @ptr"
+        #define DESC_COPY1 "sol_ptr_copy() throws SOL_ERNO_PTR when passed a " \
+                           " null pointer for @ptr"
         auto int *src = SOL_PTR_NULL;
 
 SOL_TRY:
@@ -158,29 +156,28 @@ SOL_TRY:
         sol_assert (!sol_ptr_new((sol_ptr*)&src, sizeof (int)), SOL_ERNO_TEST);
         sol_try (sol_ptr_copy(SOL_PTR_NULL, (sol_ptr*)src, sizeof (int)));
 
-                /* wind up */
-        sol_ptr_free((sol_ptr**)&src);
-
 SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
                 /* wind up */
         sol_ptr_free((sol_ptr**)&src);
-
-                /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      copy_02() - sol_ptr_copy() unit test #2
+ *      test_copy2() - sol_ptr_copy() unit test #2
  */
-static sol_erno copy_02(void)
+static sol_erno test_copy2(void)
 {
-        #define COPY_02 "sol_ptr_copy() throws SOL_ERNO_PTR when passed a"   \
-                        " pointer for @ptr that has already been allocated"
+        #define DESC_COPY2 "sol_ptr_copy() throws SOL_ERNO_PTR when passed a" \
+                           " pointer for @ptr that has already been allocated"
         auto sol_ptr *ptr = SOL_PTR_NULL;
         auto int *src = SOL_PTR_NULL;
 
@@ -190,31 +187,29 @@ SOL_TRY:
         sol_assert (!sol_ptr_new(&ptr, sizeof (int)), SOL_ERNO_TEST);
         sol_try (sol_ptr_copy(ptr, (sol_ptr*)src, sizeof (int)));
 
-                /* wind up */
-        sol_ptr_free(&ptr);
-        sol_ptr_free((sol_ptr**)&src);
-
 SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
                 /* wind up */
         sol_ptr_free(&ptr);
         sol_ptr_free((sol_ptr**)&src);
-
-                /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      copy_03() - sol_ptr_copy() unit test #3
+ *      test_copy3() - sol_ptr_copy() unit test #3
  */
-static sol_erno copy_03(void)
+static sol_erno test_copy3(void)
 {
-        #define COPY_03 "sol_ptr_copy() throws SOL_ERNO_RANGE when passed 0" \
-                        " for @sz"
+        #define DESC_COPY3 "sol_ptr_copy() throws SOL_ERNO_RANGE when passed" \
+                           " 0 for @sz"
         auto sol_ptr *ptr = SOL_PTR_NULL;
         auto int *src = SOL_PTR_NULL;
 
@@ -223,57 +218,54 @@ SOL_TRY:
         sol_assert (!sol_ptr_new((sol_ptr**)&src, sizeof (int)), SOL_ERNO_TEST);
         sol_try (sol_ptr_copy(&ptr, (sol_ptr*)src, 0));
 
-                /* wind up */
-        sol_ptr_free(&ptr);
-        sol_ptr_free((sol_ptr**)&src);
-
 SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(SOL_ERNO_RANGE == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
                 /* wind up */
         sol_ptr_free(&ptr);
         sol_ptr_free((sol_ptr**)&src);
-
-                /* check test condition */
-        return SOL_ERNO_RANGE == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      copy_04() - sol_ptr_copy() unit test #4
+ *      test_copy4() - sol_ptr_copy() unit test #4
  */
-static sol_erno copy_04(void)
+static sol_erno test_copy4(void)
 {
-        #define COPY_04 "sol_ptr_copy() throws SOL_ERNO_PTR when passed a" \
-                        " null pointer for @src"
+        #define DESC_COPY4 "sol_ptr_copy() throws SOL_ERNO_PTR when passed a" \
+                           " null pointer for @src"
         auto sol_ptr *ptr = SOL_PTR_NULL;
 
 SOL_TRY:
                 /* set up test scenario */
         sol_try (sol_ptr_copy(&ptr, SOL_PTR_NULL, sizeof (int)));
 
-                /* wind up */
-        sol_ptr_free(&ptr);
-
 SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
                 /* wind up */
         sol_ptr_free(&ptr);
-
-                /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        return sol_erno_get();
 }
 
 
 
 
-static sol_erno copy_05(void)
+static sol_erno test_copy5(void)
 {
-        #define COPY_05 "sol_ptr_copy() correctly copies the contents of @src" \
-                        " on to @ptr"
+        #define DESC_COPY5 "sol_ptr_copy() correctly copies the contents of" \
+                           " @src on to @ptr"
         auto int *ptr = SOL_PTR_NULL;
         auto int *src = SOL_PTR_NULL;
 
@@ -286,29 +278,24 @@ SOL_TRY:
                 /* check test condition */
         sol_assert (*ptr == -555, SOL_ERNO_TEST);
 
-                /* wind up */
-        sol_ptr_free((sol_ptr**)&ptr);
-        sol_ptr_free((sol_ptr**)&src);
-
 SOL_CATCH:
+SOL_FINALLY:
                 /* wind up */
         sol_ptr_free((sol_ptr**)&ptr);
         sol_ptr_free((sol_ptr**)&src);
-
-                /* throw current exception, if any */
-        sol_throw();
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      free_01() - sol_ptr_free() unit test #1
+ *      test_free1() - sol_ptr_free() unit test #1
  */
-static sol_erno free_01(void)
+static sol_erno test_free1(void)
 {
-        #define FREE_01 "sol_ptr_free() executes even if passed an invalid" \
-                        " pointer for @ptr"
+        #define DESC_FREE1 "sol_ptr_free() executes even if passed an invalid" \
+                           " pointer for @ptr"
 
                 /* set up test scenario */
         sol_ptr_free(SOL_PTR_NULL);
@@ -319,12 +306,12 @@ static sol_erno free_01(void)
 
 
 /*
- *      free_02() - sol_ptr_free() unit test #2
+ *      test_free2() - sol_ptr_free() unit test #2
  */
-static sol_erno free_02(void)
+static sol_erno test_free2(void)
 {
-        #define FREE_02 "sol_ptr_free() releases the heap memory allocated to" \
-                        " @ptr"
+        #define DESC_FREE2 "sol_ptr_free() releases the heap memory allocated" \
+                           " to @ptr"
         auto int *ptr = SOL_PTR_NULL;
 
 SOL_TRY:
@@ -337,8 +324,9 @@ SOL_TRY:
         sol_assert (!ptr, SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
@@ -362,17 +350,17 @@ SOL_TRY:
         sol_try (sol_tsuite_init2(ts, log));
 
                 /* register test cases */
-        sol_try (sol_tsuite_register(ts, &new_01, NEW_01));
-        sol_try (sol_tsuite_register(ts, &new_02, NEW_02));
-        sol_try (sol_tsuite_register(ts, &new_03, NEW_03));
-        sol_try (sol_tsuite_register(ts, &new_04, NEW_04));
-        sol_try (sol_tsuite_register(ts, &copy_01, COPY_01));
-        sol_try (sol_tsuite_register(ts, &copy_02, COPY_02));
-        sol_try (sol_tsuite_register(ts, &copy_03, COPY_03));
-        sol_try (sol_tsuite_register(ts, &copy_04, COPY_04));
-        sol_try (sol_tsuite_register(ts, &copy_05, COPY_05));
-        sol_try (sol_tsuite_register(ts, &free_01, FREE_01));
-        sol_try (sol_tsuite_register(ts, &free_02, FREE_02));
+        sol_try (sol_tsuite_register(ts, &test_new1, DESC_NEW1));
+        sol_try (sol_tsuite_register(ts, &test_new2, DESC_NEW2));
+        sol_try (sol_tsuite_register(ts, &test_new3, DESC_NEW3));
+        sol_try (sol_tsuite_register(ts, &test_new4, DESC_NEW4));
+        sol_try (sol_tsuite_register(ts, &test_copy1, DESC_COPY1));
+        sol_try (sol_tsuite_register(ts, &test_copy2, DESC_COPY2));
+        sol_try (sol_tsuite_register(ts, &test_copy3, DESC_COPY3));
+        sol_try (sol_tsuite_register(ts, &test_copy4, DESC_COPY4));
+        sol_try (sol_tsuite_register(ts, &test_copy5, DESC_COPY5));
+        sol_try (sol_tsuite_register(ts, &test_free1, DESC_FREE1));
+        sol_try (sol_tsuite_register(ts, &test_free2, DESC_FREE2));
 
                 /* execute test cases */
         sol_try (sol_tsuite_exec(ts));
@@ -382,13 +370,11 @@ SOL_TRY:
         sol_try (sol_tsuite_fail(ts, fail));
         sol_try (sol_tsuite_total(ts, total));
 
+SOL_CATCH:
+SOL_FINALLY:
                 /* wind up */
         sol_tsuite_term(ts);
-
-SOL_CATCH:
-                /* throw current exception, if any */
-        sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 

--- a/test/ts-ptr2.c
+++ b/test/ts-ptr2.c
@@ -54,9 +54,9 @@
  *      __sol_tests_ptr2() - declared in sol/test/suite.h
  */
 extern sol_erno __sol_tests_ptr2(sol_tlog *log,
-                                 int      *pass,
-                                 int      *fail,
-                                 int      *total)
+                                 int *pass,
+                                 int *fail,
+                                 int *total)
 {
 SOL_TRY:
                 /* run pointer module test cases in the simulated freestanding
@@ -64,8 +64,9 @@ SOL_TRY:
         sol_try (__sol_tests_ptr(log, pass, fail, total));
 
 SOL_CATCH:
-                /* throw current exception, if any */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 

--- a/test/ts-test.c
+++ b/test/ts-test.c
@@ -24,7 +24,12 @@
  ******************************************************************************/
 
 
+
+
+        /* include required header files */
 #include "./suite.h"
+
+
 
 
 /*
@@ -33,10 +38,14 @@
 static int flag_log = 0;
 
 
+
+
 /*
  *      flag_tcase - flag to indicate whether tcase_dummy has been called
  */
 static int flag_tcase = 0;
+
+
 
 
 /*
@@ -57,6 +66,8 @@ static void mock_log(const char *desc,
 }
 
 
+
+
 /*
  *      mock_pass() - mocks a passing test case
  */
@@ -68,9 +79,12 @@ SOL_TRY:
         flag_tcase = 1;
 
 SOL_CATCH:
-                /* control will never reach here */
-        sol_throw();
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
+
+
 
 
 /*
@@ -83,57 +97,72 @@ SOL_TRY:
         sol_assert (0, SOL_ERNO_TEST);
 
 SOL_CATCH:
-                /* control will always reach here */
+SOL_FINALLY:
+                /* wind up */
         flag_tcase = 1;
-        sol_throw();
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      init_01() - sol_tsuite_init() unit test #1
+ *      test_init1() - sol_tsuite_init() unit test #1
  */
-static sol_erno init_01(void)
+static sol_erno test_init1(void)
 {
-        #define INIT_01 "sol_tsuite_init() throws SOL_ERNO_PTR when passed" \
-                        " a null pointer for @tsuite"
+        #define DESC_INIT1 "sol_tsuite_init() throws SOL_ERNO_PTR when passed" \
+                           " a null pointer for @tsuite"
 SOL_TRY:
                 /* set up test scenario */
         sol_try (sol_tsuite_init(0));
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      init2_01() - sol_tsuite_init2() unit test #1
+ *      test_init2() - sol_tsuite_init2() unit test #1
  */
-static sol_erno init2_01(void)
+static sol_erno test_init2(void)
 {
-        #define INIT2_01 "sol_tsuite_init2() throws SOL_ERNO_PTR when passed" \
-                         " a null pointer for @tsuite"
+        #define DESC_INIT2 "sol_tsuite_init2() throws SOL_ERNO_PTR when" \
+                           " passed a null pointer for @tsuite"
 SOL_TRY:
                 /* set up test scenario */
         sol_try (sol_tsuite_init2(0, mock_log));
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      init2_02() - sol_tsuite_init2() unit test #1
+ *      test_init3() - sol_tsuite_init2() unit test #1
  */
-static sol_erno init2_02(void)
+static sol_erno test_init3(void)
 {
-        #define INIT2_02 "sol_tsuite_init2() throws SOL_ERNO_PTR when passed" \
-                         " a null pointer for @tlog"
+        #define DESC_INIT3 "sol_tsuite_init2() throws SOL_ERNO_PTR when" \
+                           " passed a null pointer for @tlog"
         auto sol_tsuite ts;
 
 SOL_TRY:
@@ -142,41 +171,53 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      register_01() - sol_tsuite_register() unit test #1
+ *      test_register1() - sol_tsuite_register() unit test #1
  */
-static sol_erno register_01(void)
+static sol_erno test_register1(void)
 {
-        #define REGISTER_01 "sol_tsuite_register() throws SOL_ERNO_PTR when" \
-                            " passed a null pointer for @tsuite"
+        #define DESC_REGISTER1 "sol_tsuite_register() throws SOL_ERNO_PTR" \
+                               " when passed a null pointer for @tsuite"
         auto sol_tsuite ts;
 
 SOL_TRY:
                 /* set up test scenario */
         sol_try (sol_tsuite_init2(&ts, mock_log));
-        sol_try (sol_tsuite_register(0, init_01, "Dummy"));
+        sol_try (sol_tsuite_register(0, test_init1, "Dummy"));
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      register_02() - sol_tsuite_register() unit test #2
+ *      test_register2() - sol_tsuite_register() unit test #2
  */
-static sol_erno register_02(void)
+static sol_erno test_register2(void)
 {
-        #define REGISTER_02 "sol_tsuite_register() throws SOL_ERNO_PTR when" \
-                            " passed a null pointer for @tcase"
+        #define DESC_REGISTER2 "sol_tsuite_register() throws SOL_ERNO_PTR" \
+                               " when passed a null pointer for @tcase"
         auto sol_tsuite ts;
 
 SOL_TRY:
@@ -186,19 +227,25 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      register_03() - sol_tsuite_register() unit test #3
+ *      test_register3() - sol_tsuite_register() unit test #3
  */
-static sol_erno register_03(void)
+static sol_erno test_register3(void)
 {
-        #define REGISTER_03 "sol_tsuite_register() throws SOL_ERNO_PTR when" \
-                            " passed a null pointer for @desc"
+        #define DESC_REGISTER3 "sol_tsuite_register() throws SOL_ERNO_PTR" \
+                               " when passed a null pointer for @desc"
         auto sol_tsuite ts;
 
 SOL_TRY:
@@ -208,19 +255,25 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      register_04() - sol_tsuite_register() unit test #4
+ *      test_register4() - sol_tsuite_register() unit test #4
  */
-static sol_erno register_04(void)
+static sol_erno test_register4(void)
 {
-        #define REGISTER_04 "sol_tsuite_register() throws SOL_ERNO_STR when" \
-                            " passed an empty string for @desc"
+        #define DESC_REGISTER4 "sol_tsuite_register() throws SOL_ERNO_STR" \
+                               " when passed an empty string for @desc"
         auto sol_tsuite ts;
 
 SOL_TRY:
@@ -230,19 +283,25 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_STR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_STR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      register_05() - sol_tsuite_register() unit test #5
+ *      test_register5() - sol_tsuite_register() unit test #5
  */
-static sol_erno register_05(void)
+static sol_erno test_register5(void)
 {
-        #define REGISTER_05 "sol_tsuite_register() truncates @desc down to" \
-                            "SOL_TCASE_MAXDESCLEN if required"
+        #define DESC_REGISTER5 "sol_tsuite_register() truncates @desc down to" \
+                                "SOL_TCASE_MAXDESCLEN if required"
         const char *desc = "This is a very long string that should be truncated"
                            " down to a maximum length defined by the symbolic"
                            " constant SOL_TCASE_MAXDESCLEN. This symbolic"
@@ -261,22 +320,24 @@ SOL_TRY:
 
                 /* check test condition; len is off by 1 */
         sol_assert (len - 1 <= SOL_TCASE_MAXDESCLEN, SOL_ERNO_TEST);
-        sol_tsuite_term(ts);
 
 SOL_CATCH:
-                /* throw exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      pass_01() - sol_tsuite_pass() unit test #1
+ *      test_pass1() - sol_tsuite_pass() unit test #1
  */
-static sol_erno pass_01(void)
+static sol_erno test_pass1(void)
 {
-        #define PASS_01 "sol_tsuite_pass() throws SOL_ERNO_PTR when passed" \
-                        " a null pointer for @tsuite"
+        #define DESC_PASS1 "sol_tsuite_pass() throws SOL_ERNO_PTR when passed" \
+                           " a null pointer for @tsuite"
         auto sol_tsuite ts;
         auto int pass;
 
@@ -287,19 +348,25 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      pass_02() - sol_tsuite_pass() unit test #2
+ *      test_pass2() - sol_tsuite_pass() unit test #2
  */
-static sol_erno pass_02(void)
+static sol_erno test_pass2(void)
 {
-        #define PASS_02 "sol_tsuite_pass() throws SOL_ERNO_PTR when passed " \
-                        " a null pointer for @pass"
+        #define DESC_PASS2 "sol_tsuite_pass() throws SOL_ERNO_PTR when passed" \
+                           " a null pointer for @pass"
         auto sol_tsuite ts;
 
 SOL_TRY:
@@ -309,20 +376,26 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      pass_03() - sol_tsuite_pass() unit test #3
+ *      test_pass3() - sol_tsuite_pass() unit test #3
  */
-static sol_erno pass_03(void)
+static sol_erno test_pass3(void)
 {
-        #define PASS_03 "sol_tsuite_pass() reports 0 for the number of passed" \
-                        " test cases if @tsuite has been initialised by"       \
-                        " sol_tsuite_init()"
+        #define DESC_PASS3 "sol_tsuite_pass() reports 0 for the number of" \
+                           " passed test cases if @tsuite has been "       \
+                           " initialised by sol_tsuite_init()"
         auto sol_tsuite __ts, *ts = &__ts;
         auto int pass;
 
@@ -334,24 +407,24 @@ SOL_TRY:
                 /* check test condition */
         sol_assert (!pass, SOL_ERNO_TEST);
 
-                /* tear down scenario */
-        sol_tsuite_term(ts);
-
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      pass_04() - sol_tsuite_pass() unit test #4
+ *      test_pass4() - sol_tsuite_pass() unit test #4
  */
-static sol_erno pass_04(void)
+static sol_erno test_pass4(void)
 {
-        #define PASS_04 "sol_tsuite_pass() reports 0 for the number of passed" \
-                        " test cases if @tsuite has been initialised by"       \
-                        " sol_tsuite_init2()"
+        #define DESC_PASS4 "sol_tsuite_pass() reports 0 for the number of" \
+                           " passed test cases if @tsuite has been"        \
+                           " initialised by sol_tsuite_init2()"
         auto sol_tsuite __ts, *ts = &__ts;
         auto int pass;
 
@@ -362,22 +435,24 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (!pass, SOL_ERNO_TEST );
-        sol_tsuite_term(ts);
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      pass_05() - sol_tsuite_pass() unit test #5
+ *      test_pass5() - sol_tsuite_pass() unit test #5
  */
-static sol_erno pass_05(void)
+static sol_erno test_pass5(void)
 {
-        #define PASS_05 "sol_tsuite_pass() reports the correct number of" \
-                        " passed test cases"
+        #define DESC_PASS5 "sol_tsuite_pass() reports the correct number of" \
+                           " passed test cases"
         auto sol_tsuite __ts, *ts = &__ts;
         auto int pass;
 
@@ -391,22 +466,24 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (1 == pass, SOL_ERNO_TEST);
-        sol_tsuite_term(ts);
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      fail_01() - sol_tsuite_fail() unit test #1
+ *      test_fail1() - sol_tsuite_fail() unit test #1
  */
-static sol_erno fail_01(void)
+static sol_erno test_fail1(void)
 {
-        #define FAIL_01 "sol_tsuite_fail() throws SOL_ERNO_PTR when passed" \
-                        " a null pointer for @tsuite"
+        #define DESC_FAIL1 "sol_tsuite_fail() throws SOL_ERNO_PTR when passed" \
+                           " a null pointer for @tsuite"
         auto sol_tsuite ts;
         auto int fail;
 
@@ -417,19 +494,25 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      fail_02() - sol_tsuite_fail() unit test #2
+ *      test_fail2() - sol_tsuite_fail() unit test #2
  */
-static sol_erno fail_02(void)
+static sol_erno test_fail2(void)
 {
-        #define FAIL_02 "sol_tsuite_fail() throws SOL_ERNO_PTR when passed" \
-                        " a null pointer for @fail"
+        #define DESC_FAIL2 "sol_tsuite_fail() throws SOL_ERNO_PTR when passed" \
+                           " a null pointer for @fail"
         auto sol_tsuite __ts, *ts = &__ts;
 
 SOL_TRY:
@@ -439,20 +522,26 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      fail_03() - sol_tsuite_fail() unit test #3
+ *      test_fail3() - sol_tsuite_fail() unit test #3
  */
-static sol_erno fail_03(void)
+static sol_erno test_fail3(void)
 {
-        #define FAIL_03 "sol_tsuite_fail() reports 0 for the number of failed" \
-                        " test cases if @tsuite has been initialised by"       \
-                        " sol_tsuite_init()"
+        #define DESC_FAIL3 "sol_tsuite_fail() reports 0 for the number of" \
+                           " failed test cases if @tsuite has been"        \
+                           " initialised by sol_tsuite_init()"
         auto sol_tsuite __ts, *ts = &__ts;
         auto int fail;
 
@@ -464,24 +553,24 @@ SOL_TRY:
                 /* check test condition */
         sol_assert (!fail, SOL_ERNO_TEST);
 
-                /* tear down scenario */
-        sol_tsuite_term(ts);
-
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      fail_04() - sol_tsuite_fail() unit test #4
+ *      test_fail4() - sol_tsuite_fail() unit test #4
  */
-static sol_erno fail_04(void)
+static sol_erno test_fail4(void)
 {
-        #define FAIL_04 "sol_tsuite_fail() reports 0 for the number of failed" \
-                        " test cases if @tsuite has been initialised by"       \
-                        " sol_tsuite_init2()"
+        #define DESC_FAIL4 "sol_tsuite_fail() reports 0 for the number of" \
+                           " failed test cases if @tsuite has been"        \
+                           " initialised by sol_tsuite_init2()"
         auto sol_tsuite __ts, *ts = &__ts;
         auto int fail;
 
@@ -492,22 +581,24 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (!fail, SOL_ERNO_TEST);
-        sol_tsuite_term(ts);
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      fail_05() - sol_tsuite_fail() unit test #5
+ *      test_fail5() - sol_tsuite_fail() unit test #5
  */
-static sol_erno fail_05(void)
+static sol_erno test_fail5(void)
 {
-        #define FAIL_05 "sol_tsuite_fail() reports the correct number of" \
-                        " failed test cases"
+        #define DESC_FAIL5 "sol_tsuite_fail() reports the correct number of" \
+                           " failed test cases"
         auto sol_tsuite __ts, *ts = &__ts;
         auto int fail;
 
@@ -522,25 +613,23 @@ SOL_TRY:
                 /* check test condition */
         sol_assert (1 == fail, SOL_ERNO_TEST);
 
-                /* tear down scenario */
-        sol_tsuite_term(ts);
-
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      total_01() - sol_tsuite_total() unit test #1
+ *      test_total1() - sol_tsuite_total() unit test #1
  */
-static sol_erno total_01(void)
+static sol_erno test_total1(void)
 {
-        #define TOTAL_01 "sol_tsuite_total() throws SOL_ERNO_PTR when passed" \
-                         " a null pointer for @tsuite"
+        #define DESC_TOTAL1 "sol_tsuite_total() throws SOL_ERNO_PTR when" \
+                            " passed a null pointer for @tsuite"
         auto sol_tsuite ts;
         auto int total;
 
@@ -551,21 +640,25 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
 
 
 /*
- *      total_02() - sol_tsuite_total() unit test #2
+ *      test_total2() - sol_tsuite_total() unit test #2
  */
-static sol_erno total_02(void)
+static sol_erno test_total2(void)
 {
-        #define TOTAL_02 "sol_tsuite_total() throws SOL_ERNO_PTR when passed" \
-                         " a null pointer for @total"
+        #define DESC_TOTAL2 "sol_tsuite_total() throws SOL_ERNO_PTR when" \
+                            " passed a null pointer for @total"
         auto sol_tsuite ts;
 
 SOL_TRY:
@@ -575,20 +668,26 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      total_03() - sol_tsuite_total() unit test #3
+ *      test_total3() - sol_tsuite_total() unit test #3
  */
-static sol_erno total_03(void)
+static sol_erno test_total3(void)
 {
-        #define TOTAL_03 "sol_tsuite_total() reports 0 for the number of"    \
-                         " total test cases if @tsuite has been initialised" \
-                         " by sol_tsuite_init()"
+        #define DESC_TOTAL3 "sol_tsuite_total() reports 0 for the number of" \
+                            " total test cases if @tsuite has been"          \
+                            " initialised by sol_tsuite_init()"
         auto sol_tsuite __ts, *ts = &__ts;
         auto int total;
 
@@ -599,23 +698,25 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (!total, SOL_ERNO_TEST);
-        sol_tsuite_term(ts);
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      total_04() - sol_tsuite_total() unit test #4
+ *      test_total4() - sol_tsuite_total() unit test #4
  */
-static sol_erno total_04(void)
+static sol_erno test_total4(void)
 {
-        #define TOTAL_04 "sol_tsuite_pass() reports 0 for the number of"     \
-                         " total test cases if @tsuite has been initialised" \
-                         " by sol_tsuite_init2()"
+        #define DESC_TOTAL4 "sol_tsuite_pass() reports 0 for the number of" \
+                            " total test cases if @tsuite has been"         \
+                            " initialised by sol_tsuite_init2()"
         auto sol_tsuite __ts, *ts = &__ts;
         auto int total;
 
@@ -626,22 +727,24 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (!total, SOL_ERNO_TEST);
-        sol_tsuite_term(ts);
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      total_05() - sol_tsuite_total() unit test #5
+ *      test_total5() - sol_tsuite_total() unit test #5
  */
-static sol_erno total_05(void)
+static sol_erno test_total5(void)
 {
-        #define TOTAL_05 "sol_tsuite_total() reports the correct number of" \
-                         " total test cases"
+        #define DESC_TOTAL5 "sol_tsuite_total() reports the correct number of" \
+                            " total test cases"
         auto sol_tsuite __ts, *ts = &__ts;
         auto int total;
 
@@ -655,22 +758,24 @@ SOL_TRY:
 
                 /* check test condition */
         sol_assert (1 == total, SOL_ERNO_TEST);
-        sol_tsuite_term(ts);
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      exec_01() - sol_tsuite_exec() unit test #1
+ *      test_exec1() - sol_tsuite_exec() unit test #1
  */
-static sol_erno exec_01(void)
+static sol_erno test_exec1(void)
 {
-        #define EXEC_01 "sol_tsuite_exec() throws SOL_ERNO_PTR when passed" \
-                        " a null pointer for @tsuite"
+        #define DESC_EXEC1 "sol_tsuite_exec() throws SOL_ERNO_PTR when passed" \
+                           " a null pointer for @tsuite"
         auto sol_tsuite ts;
 
 SOL_TRY:
@@ -680,19 +785,26 @@ SOL_TRY:
 
 SOL_CATCH:
                 /* check test condition */
-        return SOL_ERNO_PTR == sol_erno_now()
-               ? SOL_ERNO_NULL
-               : SOL_ERNO_TEST;
+        sol_erno_set(SOL_ERNO_PTR == sol_erno_get()
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
 }
 
 
+
+
 /*
- *      test_exec_02() - sol_tsuite_exec() unit test #2
+ *      test_test_exec2() - sol_tsuite_exec() unit test #2
  */
-static sol_erno exec_02(void)
+static sol_erno test_exec2(void)
 {
-        #define EXEC_02 "sol_tsuite_exec() calls the test logging callback" \
-                        " if @tsuite has been initialised by sol_tsuite_init2()"
+        #define DESC_EXEC2 "sol_tsuite_exec() calls the test logging callback" \
+                           " if @tsuite has been initialised by"               \
+                           " sol_tsuite_init2()"
         auto sol_tsuite __ts, *ts = &__ts;
 
 SOL_TRY:
@@ -705,14 +817,14 @@ SOL_TRY:
                 /* check test condition */
         sol_assert (1 == flag_log, SOL_ERNO_TEST);
 
-                /* tear down scenario */
-        sol_tsuite_term(ts);
-
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
+
+
 
 
 /*
@@ -731,31 +843,31 @@ SOL_TRY:
 
                 /* register test cases */
         sol_try (sol_tsuite_init2(ts, log));
-        sol_try (sol_tsuite_register(ts, init_01, INIT_01));
-        sol_try (sol_tsuite_register(ts, init2_01, INIT2_01));
-        sol_try (sol_tsuite_register(ts, init2_02, INIT2_02));
-        sol_try (sol_tsuite_register(ts, register_01, REGISTER_01));
-        sol_try (sol_tsuite_register(ts, register_02, REGISTER_02));
-        sol_try (sol_tsuite_register(ts, register_03, REGISTER_03));
-        sol_try (sol_tsuite_register(ts, register_04, REGISTER_04));
-        sol_try (sol_tsuite_register(ts, register_05, REGISTER_05));
-        sol_try (sol_tsuite_register(ts, pass_01, PASS_01));
-        sol_try (sol_tsuite_register(ts, pass_02, PASS_02));
-        sol_try (sol_tsuite_register(ts, pass_03, PASS_03));
-        sol_try (sol_tsuite_register(ts, pass_04, PASS_04));
-        sol_try (sol_tsuite_register(ts, pass_05, PASS_05));
-        sol_try (sol_tsuite_register(ts, fail_01, FAIL_01));
-        sol_try (sol_tsuite_register(ts, fail_02, FAIL_02));
-        sol_try (sol_tsuite_register(ts, fail_03, FAIL_03));
-        sol_try (sol_tsuite_register(ts, fail_04, FAIL_04));
-        sol_try (sol_tsuite_register(ts, fail_05, FAIL_05));
-        sol_try (sol_tsuite_register(ts, total_01, TOTAL_01));
-        sol_try (sol_tsuite_register(ts, total_02, TOTAL_02));
-        sol_try (sol_tsuite_register(ts, total_03, TOTAL_03));
-        sol_try (sol_tsuite_register(ts, total_04, TOTAL_04));
-        sol_try (sol_tsuite_register(ts, total_05, TOTAL_05));
-        sol_try (sol_tsuite_register(ts, exec_01, EXEC_01));
-        sol_try (sol_tsuite_register(ts, exec_02, EXEC_02));
+        sol_try (sol_tsuite_register(ts, test_init1, DESC_INIT1));
+        sol_try (sol_tsuite_register(ts, test_init2, DESC_INIT2));
+        sol_try (sol_tsuite_register(ts, test_init3, DESC_INIT3));
+        sol_try (sol_tsuite_register(ts, test_register1, DESC_REGISTER1));
+        sol_try (sol_tsuite_register(ts, test_register2, DESC_REGISTER2));
+        sol_try (sol_tsuite_register(ts, test_register3, DESC_REGISTER3));
+        sol_try (sol_tsuite_register(ts, test_register4, DESC_REGISTER4));
+        sol_try (sol_tsuite_register(ts, test_register5, DESC_REGISTER5));
+        sol_try (sol_tsuite_register(ts, test_pass1, DESC_PASS1));
+        sol_try (sol_tsuite_register(ts, test_pass2, DESC_PASS2));
+        sol_try (sol_tsuite_register(ts, test_pass3, DESC_PASS3));
+        sol_try (sol_tsuite_register(ts, test_pass4, DESC_PASS4));
+        sol_try (sol_tsuite_register(ts, test_pass5, DESC_PASS5));
+        sol_try (sol_tsuite_register(ts, test_fail1, DESC_FAIL1));
+        sol_try (sol_tsuite_register(ts, test_fail2, DESC_FAIL2));
+        sol_try (sol_tsuite_register(ts, test_fail3, DESC_FAIL3));
+        sol_try (sol_tsuite_register(ts, test_fail4, DESC_FAIL4));
+        sol_try (sol_tsuite_register(ts, test_fail5, DESC_FAIL5));
+        sol_try (sol_tsuite_register(ts, test_total1, DESC_TOTAL1));
+        sol_try (sol_tsuite_register(ts, test_total2, DESC_TOTAL2));
+        sol_try (sol_tsuite_register(ts, test_total3, DESC_TOTAL3));
+        sol_try (sol_tsuite_register(ts, test_total4, DESC_TOTAL4));
+        sol_try (sol_tsuite_register(ts, test_total5, DESC_TOTAL5));
+        sol_try (sol_tsuite_register(ts, test_exec1, DESC_EXEC1));
+        sol_try (sol_tsuite_register(ts, test_exec2, DESC_EXEC2));
 
                 /* execute test cases */
         sol_try (sol_tsuite_exec (ts));
@@ -764,13 +876,15 @@ SOL_TRY:
         sol_try (sol_tsuite_pass(ts, pass));
         sol_try (sol_tsuite_fail(ts, fail));
         sol_try (sol_tsuite_total(ts, total));
-        sol_tsuite_term(ts);
 
 SOL_CATCH:
-                /* throw current exception, if any */
+SOL_FINALLY:
+                /* wind up */
         sol_tsuite_term(ts);
-        sol_throw();
+        return sol_erno_get();
 }
+
+
 
 
 /******************************************************************************


### PR DESCRIPTION
The exception handling module has been enhanced with the addition of a
SOL_FINALLY block that completes the canonical try-catch-finally flow.
Simultaneously, the sol_erno_now() macro has been renamed as
sol_erno_get() so that it better matches the new sol_erno_set() macro
that has been introduced. The sol_throw() macro has also been deprecated
as it seems superfluous and a bit misleading since its behaviour is
somewhat different from the canonical throw model.

The implementation of the existing modules, along with their
corresponding unit tests, has been refactored to include the newly
developed SOL_FINALLY block.

This pull request closes #34.