### PR TITLE
Add detection of ARM processors

### DIFF
--- a/inc/env.h
+++ b/inc/env.h
@@ -26,6 +26,7 @@
 
 
 
+        /* define header guard */
 #if (!defined __SOL_ENVIRONMENT_MODULE)
 #define __SOL_ENVIRONMENT_MODULE
 
@@ -48,10 +49,9 @@
  *      compiler. However, in future, support for other compilers, including
  *      MSVC, *may* be introduced if there is adequate reason to do so.
  */
-typedef enum __SOL_ENV_CC {
-        SOL_ENV_CC_GNUC,
-        SOL_ENV_CC_CLANG
-} SOL_ENV_CC;
+#define SOL_ENV_CC       int
+#define SOL_ENV_CC_GNUC  (0)
+#define SOL_ENV_CC_CLANG (1)
 
 
 
@@ -77,14 +77,13 @@ typedef enum __SOL_ENV_CC {
  *      considered, as they are fairly archaic and limited only to deprecated
  *      compilers.
  */
-typedef enum __SOL_ENV_STDC {
-        SOL_ENV_STDC_C89,
-        SOL_ENV_STDC_C90,
-        SOL_ENV_STDC_C94,
-        SOL_ENV_STDC_C99,
-        SOL_ENV_STDC_C11,
-        SOL_ENV_STDC_C18
-} SOL_ENV_STDC;
+#define SOL_ENV_STDC     int
+#define SOL_ENV_STDC_C89 (0)
+#define SOL_ENV_STDC_C90 (1)
+#define SOL_ENV_STDC_C94 (2)
+#define SOL_ENV_STDC_C99 (3)
+#define SOL_ENV_STDC_C11 (4)
+#define SOL_ENV_STDC_C18 (5)
 
 
 
@@ -112,7 +111,7 @@ typedef enum __SOL_ENV_STDC {
  *      has been tested, and support for the others being assumed based on these
  *      tests.
  */
-#define SOL_ENV_HOST int
+#define SOL_ENV_HOST         int
 #define SOL_ENV_HOST_NONE    (0)
 #define SOL_ENV_HOST_ANDROID (1)
 #define SOL_ENV_HOST_LINUX   (2)
@@ -132,22 +131,25 @@ typedef enum __SOL_ENV_STDC {
  *        - SOL_ENV_ARCH_X68  : 32-bit x86 processor
  *        - SOL_ENV_ARCH_AMD64: 64-bit x86_64 processor
  *        - SOL_ENV_ARCH_IA64 : 64-bit Itanium processor
+ *        - SOL_ENV_ARCH_ARM  : 32-bit ARM processor
+ *        - SOL_ENV_ARCH_ARM64: 64-bit ARM64 processor
  *
  *      The SOL_ENV_ARCH type enumerates the CPU architectures supported by the
  *      Sol Library. The constants enumerated by this type are returned by the
  *      sol_env_arch() macro (defined below) in order to indicate the processor
  *      architecture at compile-time.
  *
- *      The Sol Library currently supports the 32-bit x86 family of processors,
- *      and the 64-bit x86_64 and Itanium family of processors. The Sol Library
- *      has been tested on the x86_64 architecture, and support for the others
- *      is assumed based on these tests.
+ *      The Sol Library currently supports the 32-bit ARM and x86 processor
+ *      families, and the 64-bit ARM64, x86_64 and Itanium family of processors.
+ *      The Sol Library has been tested on the x86_64 architecture, and support
+ *      for the others is assumed based on these tests.
  */
-typedef enum __SOL_ENV_ARCH {
-        SOL_ENV_ARCH_X86,
-        SOL_ENV_ARCH_AMD64,
-        SOL_ENV_ARCH_IA64
-} SOL_ENV_ARCH;
+#define SOL_ENV_ARCH       int
+#define SOL_ENV_ARCH_X86   (0)
+#define SOL_ENV_ARCH_AMD64 (1)
+#define SOL_ENV_ARCH_IA64  (2)
+#define SOL_ENV_ARCH_ARM   (3)
+#define SOL_ENV_ARCH_ARM64 (4)
 
 
 
@@ -282,6 +284,8 @@ typedef enum __SOL_ENV_ARCH {
  *        - SOL_ENV_ARCH_X68 if 32-bit x86 processor detected
  *        - SOL_ENV_ARCH_AMD64 if 64-bit x86_64 processor detected
  *        - SOL_ENV_ARCH_IA64 if 64-bit Itanium processor detected
+ *        - SOL_ENV_ARCH_ARM if 32-bit ARM processor detected
+ *        - SOL_ENV_ARCH_ARM64 if 64-bit ARM64 processor detected
  */
 #if (defined __amd64__ || defined __amd64                          \
      || defined __x86_64__  || defined __x86_64)
@@ -291,6 +295,10 @@ typedef enum __SOL_ENV_ARCH {
 #elif (defined i386 || defined __i386 || defined __i386__          \
        || defined __i486__ || defined __i586__ || defined __i686__)
 #       define sol_env_arch() SOL_ENV_ARCH_X86
+#elif (defined __arm__ || defined __thumb__)
+#       define sol_env_arch() SOL_ENV_ARCH_ARM
+#elif (defined __aarch64__)
+#       define sol_env_arch() SOL_ENV_ARCH_ARM64
 #else
 #       error "[!] sol_env_arch() error: unsupported architecture"
 #endif
@@ -312,9 +320,13 @@ typedef enum __SOL_ENV_ARCH {
  */
 #if (SOL_ENV_ARCH_X86 == sol_env_arch())
 #       define sol_env_wordsz() 32
+#elif (SOL_ENV_ARCH_ARM == sol_env_arch())
+#       define sol_env_wordsz() 32
 #elif (SOL_ENV_ARCH_AMD64 == sol_env_arch())
 #       define sol_env_wordsz() 64
 #elif (SOL_ENV_ARCH_IA64 == sol_env_arch())
+#       define sol_env_wordsz() 64
+#elif (SOL_ENV_ARCH_ARM64 == sol_env_arch())
 #       define sol_env_wordsz() 64
 #else
 #       error "[!] sol_env_wordsz() error: unsupported architecture"

--- a/test/ts-env.c
+++ b/test/ts-env.c
@@ -26,6 +26,7 @@
 
 
 
+        /* include required header files */
 #include "../inc/env.h"
 #include "./suite.h"
 
@@ -33,16 +34,21 @@
 
 
 /*
- *      cc_01() - sol_env_cc() unit test #1
+ *      test_cc1() - sol_env_cc() unit test #1
  */
-static sol_erno cc_01(void)
+static sol_erno test_cc1(void)
 {
-        #define CC_01 "sol_env_cc() is able to determine the C compiler being" \
-                      " used for compilation"
+        #define DESC_CC1 "sol_env_cc() determines the C compiler being used" \
+                         " for compilation"
+        auto SOL_ENV_CC cc;
 
 SOL_TRY:
+                /* set up test scenario */
+        cc = sol_env_cc();
+
                 /* check test condition */
-        sol_assert (sol_env_cc() >= 0, SOL_ERNO_TEST);
+        sol_assert (SOL_ENV_CC_GNUC == cc || SOL_ENV_CC_CLANG == cc,
+                    SOL_ERNO_TEST);
 
 SOL_CATCH:
 SOL_FINALLY:
@@ -54,16 +60,23 @@ SOL_FINALLY:
 
 
 /*
- *      stdc_01() - sol_env_stdc() unit test #1
+ *      test_stdc1() - sol_env_stdc() unit test #1
  */
-static sol_erno stdc_01(void)
+static sol_erno test_stdc1(void)
 {
-        #define STDC_01 "sol_env_stdc() is able to determine the standard" \
-                        " C version being used for compilation"
+        #define DESC_STDC1 "sol_env_stdc() determines the standard C version" \
+                           " being used for compilation"
+        auto SOL_ENV_STDC stdc;
 
 SOL_TRY:
+                /* set up test scenario */
+        stdc = sol_env_stdc();
+
                 /* check test condition */
-        sol_assert (sol_env_stdc() >= 0, SOL_ERNO_TEST);
+        sol_assert (SOL_ENV_STDC_C89 == stdc || SOL_ENV_STDC_C90 == stdc
+                    || SOL_ENV_STDC_C94 == stdc || SOL_ENV_STDC_C99 == stdc
+                    || SOL_ENV_STDC_C11 == stdc || SOL_ENV_STDC_C18 == stdc,
+                    SOL_ERNO_TEST);
 
 SOL_CATCH:
 SOL_FINALLY:
@@ -75,16 +88,25 @@ SOL_FINALLY:
 
 
 /*
- *      host_01() - sol_env_host() unit test #1
+ *      test_host1() - sol_env_host() unit test #1
  */
-static sol_erno host_01(void)
+static sol_erno test_host1(void)
 {
-        #define HOST_01 "sol_env_host() is able to determine the host" \
-                        " environment being used for compilation"
+        #define DESC_HOST1 "sol_env_host() determines the host environment" \
+                           " being used for compilation"
+        auto SOL_ENV_HOST host;
 
 SOL_TRY:
+                /* set up test scenario */
+        host = sol_env_host();
+
                 /* check test condition */
-        sol_assert (sol_env_host() >= 0, SOL_ERNO_TEST);
+        sol_assert (SOL_ENV_HOST_NONE == host || SOL_ENV_HOST_ANDROID == host
+                    || SOL_ENV_HOST_LINUX == host || SOL_ENV_HOST_CYGWIN == host
+                    || SOL_ENV_HOST_BSD == host || SOL_ENV_HOST_HPUX == host
+                    || SOL_ENV_HOST_AIX == host || SOL_ENV_HOST_IOS == host
+                    || SOL_ENV_HOST_OSX == host || SOL_ENV_HOST_SOLARIS == host,
+                    SOL_ERNO_TEST);
 
 SOL_CATCH:
 SOL_FINALLY:
@@ -96,16 +118,23 @@ SOL_FINALLY:
 
 
 /*
- *      arch_01() - sol_env_arch() unit test #1
+ *      test_arch1() - sol_env_arch() unit test #1
  */
-static sol_erno arch_01(void)
+static sol_erno test_arch1(void)
 {
-        #define ARCH_01 "sol_env_arch() is able to determine the CPU" \
-                        " architecture being used for compilation"
+        #define DESC_ARCH1 "sol_env_arch() determines the CPU architecture" \
+                           " being used for compilation"
+        auto SOL_ENV_ARCH arch;
 
 SOL_TRY:
+                /* set up test scenario */
+        arch = sol_env_arch();
+
                 /* check test condition */
-        sol_assert (sol_env_arch() >= 0, SOL_ERNO_TEST);
+        sol_assert (SOL_ENV_ARCH_X86 == arch || SOL_ENV_ARCH_AMD64 == arch
+                    || SOL_ENV_ARCH_IA64 == arch || SOL_ENV_ARCH_ARM == arch
+                    || SOL_ENV_ARCH_ARM64 == arch,
+                    SOL_ERNO_TEST);
 
 SOL_CATCH:
 SOL_FINALLY:
@@ -117,12 +146,12 @@ SOL_FINALLY:
 
 
 /*
- *      wordsz_01() - sol_env_wordsz() unit test #1
+ *      test_wordsz1() - sol_env_wordsz() unit test #1
  */
-static sol_erno wordsz_01(void)
+static sol_erno test_wordsz1(void)
 {
-        #define WORDSZ_01 "sol_env_arch() is able to determine the native"   \
-                          " word size of the CPU being used for compilation"
+        #define DESC_WORDSZ1 "sol_env_arch() determines the native word size" \
+                             " of the CPU being used for compilation"
 
 SOL_TRY:
                 /* check test condition */
@@ -156,11 +185,11 @@ SOL_TRY:
         sol_try (sol_tsuite_init2(ts, log));
 
                 /* register test cases */
-        sol_try (sol_tsuite_register(ts, &cc_01, CC_01));
-        sol_try (sol_tsuite_register(ts, &stdc_01, STDC_01));
-        sol_try (sol_tsuite_register(ts, &host_01, HOST_01));
-        sol_try (sol_tsuite_register(ts, &arch_01, ARCH_01));
-        sol_try (sol_tsuite_register(ts, &wordsz_01, WORDSZ_01));
+        sol_try (sol_tsuite_register(ts, &test_cc1, DESC_CC1));
+        sol_try (sol_tsuite_register(ts, &test_stdc1, DESC_STDC1));
+        sol_try (sol_tsuite_register(ts, &test_host1, DESC_HOST1));
+        sol_try (sol_tsuite_register(ts, &test_arch1, DESC_ARCH1));
+        sol_try (sol_tsuite_register(ts, &test_wordsz1, DESC_WORDSZ1));
 
                 /* execute test cases */
         sol_try (sol_tsuite_exec(ts));


### PR DESCRIPTION
The environment module of the Sol Library now supports the detection of
ARM processor through the sol_env_arch() macro. The SOL_ENV_ARCH
enumeration now includes the SOL_ENV_ARCH_ARM and SOL_ENV_ARCH_ARM64
constants to represent the ARM and ARM64 processors respectively.

The SOL_ENV_CC and SOL_ENV_STDC enumerations have also been refactored
so as to enable them to be used outside function definitions. The unit
tests of the environment module have also been refactored.

This pull request closes #39.