### PR TITLE
Add logging module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,12 @@ OPT_COV = -o $(DIR_BLD)
 
 
 # 	Set command inputs
-INP_SO  = $(DIR_BLD)/test.o $(DIR_BLD)/ptr.o
+INP_SO  = $(DIR_BLD)/error.o $(DIR_BLD)/test.o $(DIR_BLD)/ptr.o $(DIR_BLD)/log.o
 INP_LD  = $(DIR_TEST)/runner.c $(DIR_TEST)/ts-error.c $(DIR_TEST)/ts-test.c \
 	  $(DIR_TEST)/ts-hint.c $(DIR_TEST)/ts-env.c $(DIR_TEST)/ts-ptr.c   \
-	  $(DIR_TEST)/ts-ptr2.c
-INP_COV = $(DIR_BLD)/test.gcda $(DIR_BLD)/ptr.gcda
+	  $(DIR_TEST)/ts-ptr2.c $(DIR_TEST)/ts-log.o
+INP_COV = $(DIR_BLD)/error.gcda $(DIR_BLD)/test.gcda $(DIR_BLD)/ptr.gcda \
+	  $(DIR_BLD)/log.gcda
 INP_RUN = $(DIR_BLD)/test.log
 
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ software development that leverages the power of C without sacrificing on
 progressive best practices. The secondary goal of the Library is that it should
 be usable on a freestanding environment; although I don't have any experience in 
 embedded programming, it's nice to envision that this Library is usable in such
-environments. These goals are achieved through **five modules**, which are 
+environments. These goals are achieved through **seven modules**, which are 
 described in the [Features](#features) section of this document.
 
 
@@ -63,24 +63,31 @@ The documentation for the Sol Library is structured as follows:
 
 The Sol Library is designed as a set of modules, with each module responsible
 for providing a specific set of related functionality:
-  1. The **Environment Module** helps identify the compiler and host environment
+  1. The **Environment Module** provides diagnostics related to the compilation
+     environment
   2. The **Compiler Hints Module** provides compiler hints that can potentially
      optimise code
-  3. The **Primitive Data Types Module** defines the primitive data types along
+  3. The **Libc Module** provides portably access to libc dependencies
+  4. The **Primitive Data Types Module** defines the primitive data types along
      with their related constants
-  4. The **Exception Handling Module** provides a basic structure to handle
+  5. The **Exception Handling Module** provides a basic structure to handle
      exceptions
-  5. The **Unit Testing Module** provides a framework for executing unit tests
+  6. The **Unit Testing Module** provides a framework for executing unit tests
+  7. The **Logging Module** provides support for runtime logging
 
-This Library does not have any external dependencies that require a hosted
-environment, and so may be used even in freestanding environments. The `stdio.h`
-header file is required for running the unit tests, but is __not__ required by
-the Library otherwise.
+Although this Library depends on a few libc functions, most notably malloc() and
+free(), the Libc Module provides the means for freestanding environments to hook
+their own libc implementations to the Sol Library. In future, I hope to be able
+to provide a fallback libc implementation for freestanding environments that do
+not provide their own.
 
-Every attempt has been made to make this Library as portable as possible. A
-deliberate choice was taken to use the C99 standard in order to take advantage
-of the new types introduced by it. Until a specific use case arises for the use
-of the C89 standard (or any other), C99 will be considered the default standard.
+Every attempt has been made to make this Library as portable as possible. The
+Sol Library has been designed to be compatible with the C89 standard, but takes
+advantage of the improved features provided by the newer dialects if supported
+by the compilation environment.
+
+Although this Library takes advantage of the features provided by C99 and newer
+dialects, it will compile fine on the C89
 
 The enhanced features of compiler hints and support for 64-bit integers are
 considered to be optional, and are available only when GCC/Clang or a GCC-

--- a/inc/env.h
+++ b/inc/env.h
@@ -335,6 +335,37 @@
 
 
 
+/*
+ *      sol_env_file() - introspects current file name
+ */
+#define sol_env_file() __FILE__
+
+
+
+
+/*
+ *      sol_env_func() - introspects current function name
+ */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define sol_env_func() __func__
+#elif (sol_env_cc() == SOL_ENV_CC_GNUC || sol_env_cc() == SOL_ENV_CC_CLANG)
+#       define sol_env_func() __FUNCTION__
+#else
+#       define sol_env_func() "<unknown>"
+#       warning "[!] sol_env_func() warning: unable to determine function name"
+#endif
+
+
+
+
+/*
+ *      sol_env_line() - introspects current line number
+ */
+#define sol_env_line() __LINE__
+
+
+
+
 #endif /* (!defined __SOL_ENVIRONMENT_MODULE) */
 
 

--- a/inc/error.h
+++ b/inc/error.h
@@ -134,6 +134,22 @@ typedef size_t sol_erno;
 
 
 /*
+ *      SOL_ERNO_FILE - file error
+ */
+#define SOL_ERNO_FILE ((sol_erno)0x6)
+
+
+
+
+/*
+ *      SOL_ERNO_STATE - invalid state
+ */
+#define SOL_ERNO_STATE ((sol_erno)0x7)
+
+
+
+
+/*
  *      SOL_TRY - start of try block
  *
  *      The SOL_TRY label identifies the starting point of the try block within
@@ -210,8 +226,13 @@ typedef size_t sol_erno;
  *        - SOL_ERNO if no error has occured
  *        - The current error code if an error has occured
  */
-#define /* const sol_erno */ sol_erno_get(/* void */) \
+#define /* sol_erno */ sol_erno_get(/* void */) \
         ((const sol_erno) __sol_erno)
+
+
+
+
+extern const char *sol_erno_str(sol_erno erno);
 
 
 

--- a/inc/libc.h
+++ b/inc/libc.h
@@ -1,0 +1,212 @@
+/******************************************************************************
+ *                           SOL LIBRARY v0.1.0+41
+ *
+ * File: sol/inc/libc.h
+ *
+ * Description:
+ *      This file is part of the API of the Sol Library. It declares the
+ *      interface of the libc compatibility module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* define header guard */
+#if (!defined __SOL_LIBC_COMPATIBILITY_MODULE)
+#define __SOL_LIBC_COMPATIBILITY_MODULE
+
+
+
+
+        /* include required header files */
+#include "./env.h"
+#if (sol_env_host() != SOL_ENV_HOST_NONE)
+#       include <stdio.h>
+#       include <stdlib.h>
+#       include <time.h>
+#endif
+
+
+
+
+/*
+ *      SOL_LIBC_FILE_DEFINED - stdio.h FILE defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (!defined SOL_LIBC_FILE_DEFINED)
+#               error "[!] Sol libc error: FILE not defined"
+#       endif
+#else
+#       define SOL_LIBC_FILE_DEFINED
+#endif
+
+
+
+
+/*
+ *      SOL_LIBC_TIME_T_DEFINED - time.h time_t defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (!defined SOL_LIBC_TIME_T_DEFINED)
+#               error "[!] Sol libc error: time_t not defined"
+#       endif
+#else
+#       define SOL_LIBC_TIME_T_DEFINED
+#endif
+
+
+
+
+/*
+ *      SOL_LIBC_FOPEN_DEFINED - stdio.h fopen() defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (defined SOL_LIBC_FOPEN_DEFINED)
+                extern FILE *fopen(const char*, const char*);
+#       else
+#               error "[!] Sol libc error: fopen() not defined"
+#       endif
+#else
+#       define SOL_LIBC_FOPEN_DEFINED
+#endif
+
+
+
+
+/*
+ *      SOL_LIBC_FCLOSE_DEFINED - stdio.h fclose() defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (defined SOL_LIBC_FCLOSE_DEFINED)
+                extern int fclose(FILE*);
+#       else
+#               error "[!] Sol libc error: fclose() not defined"
+#       endif
+#else
+#       define SOL_LIBC_FCLOSE_DEFINED
+#endif
+
+
+
+
+/*
+ *      SOL_LIBC_FPRINTF_DEFINED - stdio.h fprintf() defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (defined SOL_LIBC_FPRINTF_DEFINED)
+                extern int fprintf(FILE*, const char*, ...);
+#       else
+#               error "[!] Sol libc error: fprintf() not defined"
+#       endif
+#else
+#       define SOL_LIBC_FPRINTF_DEFINED
+#endif
+
+
+
+
+/*
+ *      SOL_LIBC_FGETS_DEFINED - stdio.h fgets() defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (defined SOL_LIBC_FGETS_DEFINED)
+                extern char *fgets(char *s, int size, FILE *stream);
+#       else
+#               error "[!] Sol libc error: fgets() not defined"
+#       endif
+#else
+#       define SOL_LIBC_FGETS_DEFINED
+#endif
+
+
+
+
+/*
+ *      SOL_LIBC_MALLOC_DEFINED - stdlib.h malloc() defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (defined SOL_LIBC_MALLOC_DEFINED)
+                extern void *malloc(size_t);
+#       else
+#               error "[!] Sol libc error: malloc() not defined"
+#       endif
+#else
+#       define SOL_LIBC_FPRINTF_DEFINED
+#endif
+
+
+
+
+/*
+ *      SOL_LIBC_FREE_DEFINED - stdlib.h free() defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (defined SOL_LIBC_MALLOC_DEFINED)
+                extern void free(void*);
+#       else
+#               error "[!] Sol libc error: free() not defined"
+#       endif
+#else
+#       define SOL_LIBC_FPRINTF_DEFINED
+#endif
+
+
+
+
+/*
+ *      SOL_LIBC_TIME_DEFINED - time.h time() defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (defined SOL_LIBC_TIME_DEFINED)
+                extern time_t time(time_t*);
+#       else
+#               error "[!] Sol libc error: time() not defined"
+#       endif
+#else
+#       define SOL_LIBC_TIME_DEFINED
+#endif
+
+
+
+
+/*
+ *      SOL_LIBC_CTIME_DEFINED - time.h ctime() defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (defined SOL_LIBC_CTIME_DEFINED)
+                extern char *ctime(const time_t*);
+#       else
+#               error "[!] Sol libc error: ctime() not defined"
+#       endif
+#else
+#       define SOL_LIBC_CTIME_DEFINED
+#endif
+
+
+
+
+#endif /* !defined __SOL_LIBC_COMPATIBILITY_MODULE */
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/inc/log.h
+++ b/inc/log.h
@@ -1,0 +1,237 @@
+/******************************************************************************
+ *                           SOL LIBRARY v0.1.0+41
+ *
+ * File: sol/inc/log.h
+ *
+ * Description:
+ *      This file is part of the API of the Sol Library. It declares the
+ *      interface of the logging module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* create header guard */
+#if (!defined __SOL_LOGGING_MODULE)
+#define __SOL_LOGGING_MODULE
+
+
+
+
+        /* include required header files */
+#include "./env.h"
+#include "./error.h"
+
+
+
+
+/*
+ *      sol_log_open() - opens log file
+ *        - path: log file path
+ *
+ *      The sol_log_open() interface function opens the log file located at
+ *      @path, and sets it as the default log file where the log entries will be
+ *      written by the logging module. This function flushes out the contents of
+ *      the log file at @path if it exists, and creates it if it does not exist.
+ *
+ *      @path is required to be a valid non-null string, or else an exception is
+ *      thrown. An error is also raised in case the log file at @path has
+ *      already been opened by an earlier call to either sol_log_open() or
+ *      sol_log_open2().
+ *
+ *      Return:
+ *        - SOL_ERNO_NULL if no error occurs
+ *        - SOL_ERNO_STATE if log file is already open
+ *        - SOL_ERNO_STR if @path is invalid
+ *        - SOL_ERNO_FILE if log file can't be opened
+ */
+extern sol_erno sol_log_open(const char *path);
+
+
+
+
+/*
+ *      sol_log_open2() - opens log file
+ *        - path: log file path
+ *        - flush: flag to indicate whether log file should be flushed
+ *
+ *      The sol_log_open2() interface function is the overloaded form of the
+ *      sol_log_open() function declared above. This function, like its original
+ *      form, opens the log file located @path, and sets it as the default log
+ *      file where the log entries will be written by the logging module. In
+ *      addition, this function allows a flag @flush to explicitly specify
+ *      whether or not the contents of the log file should be flushed on
+ *      opening in case file already exists. If the file does not exist, then
+ *      this function creates it.
+ *
+ *      @path is required to be a valid non-null string, or else an exception is
+ *      thrown. An error is also raised in case the log file at @path has
+ *      already been opened by an earlier call to either sol_log_open() or
+ *      sol_log_open2().
+ *
+ *      Return:
+ *        - SOL_ERNO_NULL if no error occurs
+ *        - SOL_ERNO_STATE if log file is already open
+ *        - SOL_ERNO_STR if @path is invalid
+ *        - SOL_ERNO_FILE if log file can't be opened
+ */
+extern sol_erno sol_log_open2(const char *path,
+                              int flush);
+
+
+
+
+/*
+ *      sol_log_close() - closes log file
+ *
+ *      The sol_log_close() interface function closes the log file that has been
+ *      opened by an earlier call to either sol_log_open() or sol_log_open2().
+ *      Calling this function when no log file is currently open results in a
+ *      safe no-op.
+ *
+ *      This function must be called when the logging module is no longer
+ *      required in order to prevent a resource leak.
+ */
+extern void sol_log_close(void);
+
+
+
+
+/*
+ *      sol_log_trace() - logs a trace message
+ *        - msg: message
+ *
+ *      The sol_log_trace() interface macro records a trace message @msg to the
+ *      currently open log file. The current local timestamp and code location
+ *      are automatically prefixed to @msg. It is safe to call this macro even
+ *      if no log file is currently open.
+ */
+#define /* void */ sol_log_trace(/* const char* */ msg) \
+        __sol_log_write("T",                            \
+                        sol_env_func(),                 \
+                        sol_env_file(),                 \
+                        sol_env_line(),                 \
+                        (msg))
+
+
+
+
+/*
+ *      sol_log_debug() - logs a debug message
+ *        - msg: message
+ *
+ *      The sol_log_debug() interface macro records a debug message @msg to the
+ *      currently open log file. The current local timestamp and code location
+ *      are automatically prefixed to @msg. It is safe to call this macro even
+ *      if no log file is currently open.
+ */
+#define /* void */ sol_log_debug(/* const char* */ msg) \
+        __sol_log_write("D",                            \
+                        sol_env_func(),                 \
+                        sol_env_file(),                 \
+                        sol_env_line(),                 \
+                        (msg))
+
+
+
+
+/*
+ *      sol_log_warn() - logs a warning message
+ *        - msg: message
+ *
+ *      The sol_log_warn() interface macro records a warning message @msg to the
+ *      currently open log file. The current local timestamp and code location
+ *      are automatically prefixed to @msg. It is safe to call this macro even
+ *      if no log file is currently open.
+ */
+#define /* void */ sol_log_warn(/* const char* */ msg) \
+        __sol_log_write("W",                           \
+                        sol_env_func(),                \
+                        sol_env_file(),                \
+                        sol_env_line(),                \
+                        (msg))
+
+
+
+
+/*
+ *      sol_log_error() - logs an error message
+ *        - msg: message
+ *
+ *      The sol_log_error() interface macro records an error message @msg to the
+ *      currently open log file. The current local timestamp and code location
+ *      are automatically prefixed to @msg. It is safe to call this macro even
+ *      if no log file is currently open.
+ */
+#define /* void */ sol_log_error(/* const char* */ msg) \
+        __sol_log_write("E",                            \
+                        sol_env_func(),                 \
+                        sol_env_file(),                 \
+                        sol_env_line(),                 \
+                        (msg))
+
+
+
+
+/*
+ *      sol_log_erno() - log an error code
+ *        - erno: error code
+ *
+ *      The sol_log_erno() interface macro records an error code @erno to the
+ *      currently open log file. The current local timestamp and code location
+ *      are automatically prefixed to @msg. It is safe to call this macro even
+ *      if no log file is currently open.
+ */
+#define /* void */ sol_log_erno(/* sol_erno */ erno) \
+        __sol_log_write("E",                         \
+                        sol_env_func(),              \
+                        sol_env_file(),              \
+                        sol_env_line(),              \
+                        sol_erno_str((erno)))
+
+
+
+
+/*
+ *      __sol_log_write() - writes a log entry
+ *
+ *      The __sol_log_write() function is **not** a part of the interface of the
+ *      logging module, and must **not** be called directly. This function is a
+ *      utility function that helps in writing log entries to the log file, and
+ *      has been declared in this file so that it can be called by the logging
+ *      macros defined above.
+ */
+extern void __sol_log_write(const char *type,
+                            const char *func,
+                            const char *file,
+                            int line,
+                            const char *msg);
+
+
+
+
+#endif /* !defined __SOL_LOGGING_MODULE */
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/inc/test.h
+++ b/inc/test.h
@@ -75,8 +75,7 @@
  *        - SOL_ERNO_NULL if the test case passes
  *        - A context-sensitive error code if the test case fails
  */
-typedef sol_erno
-(sol_tcase)(void);
+typedef sol_erno (sol_tcase)(void);
 
 
 
@@ -96,10 +95,8 @@ typedef sol_erno
  *      each test case executed, along with the error code @erno returned by the
  *      test case.
  */
-typedef void
-(sol_tlog)(char     const *desc,
-           sol_erno const erno
-          );
+typedef void (sol_tlog)(const char *desc,
+                        sol_erno erno);
 
 
 
@@ -117,11 +114,11 @@ typedef void
  *      and unsed only through its interface functions declared below.
  */
 typedef struct __sol_tsuite {
-        int       total;
-        int       fail;
-        char      desc   [SOL_TSUITE_MAXTCASE] [SOL_TCASE_MAXDESCLEN];
-        sol_tcase *tcase [SOL_TSUITE_MAXTCASE];
-        sol_tlog  *tlog;
+        int total;
+        int fail;
+        char desc[SOL_TSUITE_MAXTCASE][SOL_TCASE_MAXDESCLEN];
+        sol_tcase *tcase[SOL_TSUITE_MAXTCASE];
+        sol_tlog *tlog;
 } sol_tsuite;
 
 
@@ -146,8 +143,7 @@ typedef struct __sol_tsuite {
  *        - SOL_ERNO_NULL if no error occurs
  *        - SOL_ERNO_PTR if an invalid pointer is passed
  */
-extern sol_erno
-sol_tsuite_init(sol_tsuite *tsuite);
+extern sol_erno sol_tsuite_init(sol_tsuite *tsuite);
 
 
 
@@ -155,7 +151,7 @@ sol_tsuite_init(sol_tsuite *tsuite);
 /*
  *      sol_tsuite_init2() - initialises test suite
  *        - tsuite: contextual test suite
- *        - tlog  : test logging callback
+ *        - tlog: test logging callback
  *
  *     The sol_tsuite_init2() interface function is the overloaded form of the
  *     sol_tsuite_init() function declared above. This function, like its
@@ -172,10 +168,8 @@ sol_tsuite_init(sol_tsuite *tsuite);
  *       - SOL_ERNO_NULL if no error occurs
  *       - SOL_ERNO_PTR if an invalid pointer is passed as an argument
  */
-extern sol_erno
-sol_tsuite_init2(sol_tsuite *tsuite,
-                 sol_tlog   *tlog
-                );
+extern sol_erno sol_tsuite_init2(sol_tsuite *tsuite,
+                                 sol_tlog *tlog);
 
 
 
@@ -190,8 +184,7 @@ sol_tsuite_init2(sol_tsuite *tsuite,
  *      @tsuite to be a valid pointer, a safe no-op occurs if this condition is
  *      not satisfied.
  */
-extern void
-sol_tsuite_term(sol_tsuite *tsuite);
+extern void sol_tsuite_term(sol_tsuite *tsuite);
 
 
 
@@ -199,8 +192,8 @@ sol_tsuite_term(sol_tsuite *tsuite);
 /*
  *      sol_tsuite_register() - registers a test case
  *        - tsuite: contextual test suite
- *        - tcase : test case to register
- *        - desc  : test case description
+ *        - tcase: test case to register
+ *        - desc: test case description
  *
  *     The sol_tsuite_register() interface function registers a test case @tcase
  *     described by @desc with a test suite @tsuite. A test case must first be
@@ -219,11 +212,9 @@ sol_tsuite_term(sol_tsuite *tsuite);
  *       - SOL_ERNO_STR if @desc is a null string
  *       - SOL_ERNO_RANGE if the limit of registered test cases is exceeded
  */
-extern sol_erno
-sol_tsuite_register(sol_tsuite       *tsuite,
-                    sol_tcase        *tcase,
-                    char       const *desc
-                   );
+extern sol_erno sol_tsuite_register(sol_tsuite *tsuite,
+                                    sol_tcase *tcase,
+                                    const char *desc);
 
 
 
@@ -231,7 +222,7 @@ sol_tsuite_register(sol_tsuite       *tsuite,
 /*
  *      sol_tsuite_pass() - count of passed test cases
  *        - tsuite: contextual test suite
- *        - pass  : count of passed test cases
+ *        - pass: count of passed test cases
  *
  *      The sol_tsuite_pass() interface function returns the number of test
  *      cases @pass of a test suite @tsuite that have been successfully run
@@ -244,10 +235,8 @@ sol_tsuite_register(sol_tsuite       *tsuite,
  *        - SOL_ERNO_NULL if no error occurs
  *        - SOL_ERNO_PTR if an invalid pointer is passed as an argument
  */
-extern sol_erno
-sol_tsuite_pass(sol_tsuite const *tsuite,
-                int              *pass
-               );
+extern sol_erno sol_tsuite_pass(const sol_tsuite *tsuite,
+                                int *pass);
 
 
 
@@ -255,7 +244,7 @@ sol_tsuite_pass(sol_tsuite const *tsuite,
 /*
  *      sol_tsuite_fail() - count of failed test cases
  *        - tsuite: contextual test suite
- *        - fail  : count of failed test cases
+ *        - fail: count of failed test cases
  *
  *      The sol_tsuite_fail() interface function returns the number of test
  *      cases @fail of a test suite @tsuite that have failed when executed
@@ -268,10 +257,8 @@ sol_tsuite_pass(sol_tsuite const *tsuite,
  *        - SOL_ERNO_NULL if no error occurs
  *        - SOL_ERNO_PTR if an invalid pointer is passed as an argument
  */
-extern sol_erno
-sol_tsuite_fail(sol_tsuite const *tsuite,
-                int              *fail
-               );
+extern sol_erno sol_tsuite_fail(const sol_tsuite *tsuite,
+                                int *fail);
 
 
 
@@ -279,7 +266,7 @@ sol_tsuite_fail(sol_tsuite const *tsuite,
 /*
  *      sol_tsuite_total() - count of total test cases
  *        - tsuite: contextual test suite
- *        - total : count of total test cases
+ *        - total: count of total test cases
  *
  *      The sol_tsuite_total() interface function returns the total number of
  *      test cases @total registered with a test suite @tsuite.
@@ -291,10 +278,8 @@ sol_tsuite_fail(sol_tsuite const *tsuite,
  *        - SOL_ERNO_NULL if no error occurs
  *        - SOL_ERNO_PTR if an invalid pointer is passed as an argument
  */
-extern sol_erno
-sol_tsuite_total(sol_tsuite const *tsuite,
-                 int              *total
-                );
+extern sol_erno sol_tsuite_total(const sol_tsuite *tsuite,
+                                 int *total);
 
 
 
@@ -316,8 +301,7 @@ sol_tsuite_total(sol_tsuite const *tsuite,
  *        - SOL_ERNO_NULL if no error occurs
  *        - SOL_ERNO_PTR if an invalid argument is passed
  */
-extern sol_erno
-sol_tsuite_exec(sol_tsuite *tsuite);
+extern sol_erno sol_tsuite_exec(sol_tsuite *tsuite);
 
 
 

--- a/src/error.c
+++ b/src/error.c
@@ -1,0 +1,83 @@
+/******************************************************************************
+ *                           SOL LIBRARY v1.0.0+41
+ *
+ * File: sol/src/error.c
+ *
+ * Description:
+ *      This file is part of the internal implementation of the Sol Library.
+ *      It implements the exception handling module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* include required header files */
+#include "../inc/error.h"
+
+
+
+
+/*
+ *      BFR_LEN - length of string buffer
+ */
+#define BFR_LEN 19
+
+
+
+
+/*
+ *      BFR_HND - handle to string buffer
+ */
+static sol_tls char bfr_hnd[BFR_LEN];
+
+
+
+
+/*
+ *      sol_erno_str() - declared in sol/inc/error.h
+ */
+extern const char *sol_erno_str(sol_erno erno)
+{
+        const int RADIX = 16;
+        register int i = 0;
+
+                /* prefix with '0x' to indicate hex code */
+        bfr_hnd[i] = '0';
+        bfr_hnd[++i] = 'x';
+
+                /* convert erno to hex string representation with padding zeros
+                 * as required; this code has been adapted from that posted by
+                 * user Lundin on StackOverflow */
+        for (++i; i < BFR_LEN; i++) {
+                bfr_hnd[BFR_LEN - i] = (erno % RADIX) + '0';
+                erno /= RADIX;
+        }
+
+                /* close buffer and return it */
+        bfr_hnd[i] = '\0';
+        return bfr_hnd;
+}
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,152 @@
+/******************************************************************************
+ *                           SOL LIBRARY v1.0.0+41
+ *
+ * File: sol/src/log.c
+ *
+ * Description:
+ *      This file is part of the internal implementation of the Sol Library.
+ *      It implements the logging module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* include required header files */
+#include "../inc/hint.h"
+#include "../inc/libc.h"
+#include "../inc/log.h"
+#include "../inc/ptr.h"
+
+
+
+
+/*
+ *      log_hnd - handle to log file
+ */
+static sol_tls FILE *log_hnd = SOL_PTR_NULL;
+
+
+
+
+/*
+ *      sol_log_open() - declared in sol/inc/log.h
+ */
+extern sol_erno sol_log_open(const char *path)
+{
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (!log_hnd, SOL_ERNO_STATE);
+        sol_assert (path && *path, SOL_ERNO_STR);
+
+                /* open the log file using the standard fopen() function
+                 * provided by the libc module */
+        log_hnd = fopen(path, "w"); /* NOLINT */
+        sol_assert (log_hnd, SOL_ERNO_FILE);
+
+SOL_CATCH:
+                /* nothing to do if an exception occurs */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      sol_log_open2() - declared in sol/inc/log.h
+ */
+extern sol_erno sol_log_open2(const char *path,
+                              const int flush)
+{
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (!log_hnd, SOL_ERNO_STATE);
+        sol_assert (path && *path, SOL_ERNO_STR);
+
+                /* open the log file, flushing it if required; we use the
+                 * standard fopen() function provided by the libc module */
+        log_hnd = fopen(path, flush ? "w" : "a+");
+        sol_assert (log_hnd, SOL_ERNO_FILE);
+
+SOL_CATCH:
+                /* nothing to do if an exception occurs */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      sol_log_close() - declared in sol/inc/log.h
+ */
+extern void sol_log_close(void)
+{
+                /* close log file if it's open; we use the standard fclose()
+                 * function provided by the libc module */
+        if (log_hnd) {
+                (void) fclose(log_hnd);
+                log_hnd = SOL_PTR_NULL;
+        }
+}
+
+
+
+
+/*
+ *      __sol_log_write() - declared in sol/inc/log.h
+ *        - type: log entry type - (T)race, (D)ebug, or (E)rror
+ *        - func: function name of log entry source
+ *        - file: file name of log entry source
+ *        - line: line number of log entry source
+ *        - msg: log message
+ */
+extern void __sol_log_write(const char *type,
+                            const char *func,
+                            const char *file,
+                            int line,
+                            const char *msg)
+{
+        const char *FMT = "[%s] [%.24s] [%s():%s:%d] %s\n";
+        auto time_t tm;
+        auto char *ctm;
+
+                /* determine current local time */
+        (void) time(&tm);
+        ctm = ctime(&tm);
+
+                /* write entry to log file if it's open and @msg is valid; the
+                 * former check is necessary because the logging macros may be
+                 * called even if the log file hasn't been opened */
+        if (sol_likely (log_hnd && msg && *msg)) {
+                (void) fprintf(log_hnd, FMT, type, ctm, func, file, line, msg);
+        }
+}
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/src/ptr.c
+++ b/src/ptr.c
@@ -28,21 +28,9 @@
 
         /* include required header files */
 #include "../inc/env.h"
+#include "../inc/libc.h"
+#include "../inc/log.h"
 #include "../inc/ptr.h"
-
-
-
-
-        /* the implementation of the pointer module uses the standard malloc()
-         * and free() functions; in hosted environments, these are provided by
-         * the standard stdlib.h header file, and in freestanding environments
-         * by the client code (until an allocator is implemented in future) */
-#if (SOL_ENV_HOST_NONE == sol_env_host())
-        extern void *malloc(size_t);
-        extern void free(void*);
-#else
-#       include <stdlib.h>
-#endif
 
 
 
@@ -85,6 +73,9 @@ SOL_TRY:
         sol_assert ((*ptr = malloc(sz)), SOL_ERNO_HEAP);
 
 SOL_CATCH:
+                /* log current error */
+        sol_log_erno(sol_erno_get());
+
 SOL_FINALLY:
                 /* wind up */
         return sol_erno_get();
@@ -110,6 +101,9 @@ SOL_TRY:
         copy_byte(ptr, src, len);
 
 SOL_CATCH:
+                /* log current error */
+        sol_log_erno(sol_erno_get());
+
 SOL_FINALLY:
                 /* wind up */
         return sol_erno_get();

--- a/src/test.c
+++ b/src/test.c
@@ -26,28 +26,27 @@
 
 
 
-/*
- *      Include required header files.
- */
+        /* include required header files */
 #include "../inc/test.h"
+#include "../inc/log.h"
 
 
 
 
 /*
  *      tsuite_init() - initialises test suite member fields
+ *        - tsuite: contextual test suite
+ *        - tlog: logging callback
  */
-static void
-tsuite_init(sol_tsuite *tsuite, /* contextual test suite */
-            sol_tlog   *tlog    /* logging callback      */
-           )
+static void tsuite_init(sol_tsuite *tsuite,
+                        sol_tlog *tlog)
 {
         register int i;
 
                 /* initialise counters and logging callback */
         tsuite->total = 0;
-        tsuite->fail  = 0;
-        tsuite->tlog  = tlog;
+        tsuite->fail = 0;
+        tsuite->tlog = tlog;
 
                 /* initialise test case callback and description arrays */
         for (i = 0; i < SOL_TSUITE_MAXTCASE; i++) {
@@ -62,8 +61,7 @@ tsuite_init(sol_tsuite *tsuite, /* contextual test suite */
 /*
  *      sol_tsuite_init() - declared in sol/inc/test.h
  */
-extern sol_erno
-sol_tsuite_init(sol_tsuite *tsuite)
+extern sol_erno sol_tsuite_init(sol_tsuite *tsuite)
 {
 SOL_TRY:
                 /* check preconditions */
@@ -74,6 +72,9 @@ SOL_TRY:
         tsuite_init (tsuite, 0);
 
 SOL_CATCH:
+                /* log current error code */
+        sol_log_erno(sol_erno_get());
+
 SOL_FINALLY:
                 /* wind up */
         return sol_erno_get();
@@ -85,10 +86,8 @@ SOL_FINALLY:
 /*
  *      sol_tsuite_init2() - declared in sol/inc/test.h
  */
-extern sol_erno
-sol_tsuite_init2(sol_tsuite *tsuite,
-                 sol_tlog   *tlog
-                )
+extern sol_erno sol_tsuite_init2(sol_tsuite *tsuite,
+                                 sol_tlog *tlog)
 {
 SOL_TRY:
                 /* check preconditions */
@@ -99,6 +98,9 @@ SOL_TRY:
         tsuite_init (tsuite, tlog);
 
 SOL_CATCH:
+                /* log current error code */
+        sol_log_erno(sol_erno_get());
+
 SOL_FINALLY:
                 /* wind up */
         return sol_erno_get();
@@ -126,11 +128,9 @@ sol_tsuite_term(sol_tsuite *tsuite)
 /*
  *      sol_tsuite_register() - declared in sol/inc/test.h
  */
-extern sol_erno
-sol_tsuite_register(sol_tsuite       *tsuite,
-                    sol_tcase        *tcase,
-                    char       const *desc
-                   )
+extern sol_erno sol_tsuite_register(sol_tsuite *tsuite,
+                                    sol_tcase *tcase,
+                                    const char *desc)
 {
         register int len;
         register char *itr;
@@ -160,6 +160,9 @@ SOL_TRY:
         tsuite->total++;
 
 SOL_CATCH:
+                /* log current error code */
+        sol_log_erno(sol_erno_get());
+
 SOL_FINALLY:
                 /* wind up */
         return sol_erno_get();
@@ -171,10 +174,8 @@ SOL_FINALLY:
 /*
  *      sol_tsuite_pass() - declared in sol/inc/test.h
  */
-extern sol_erno
-sol_tsuite_pass(sol_tsuite const *tsuite,
-                int              *pass
-               )
+extern sol_erno sol_tsuite_pass(const sol_tsuite *tsuite,
+                                int *pass)
 {
 SOL_TRY:
                 /* check preconditions */
@@ -184,6 +185,9 @@ SOL_TRY:
         *pass = tsuite->total - tsuite->fail;
 
 SOL_CATCH:
+                /* log current error code */
+        sol_log_erno(sol_erno_get());
+
 SOL_FINALLY:
                 /* wind up */
         return sol_erno_get();
@@ -195,10 +199,8 @@ SOL_FINALLY:
 /*
  *      sol_tsuite_fail() - declared in sol/inc/test.h
  */
-extern sol_erno
-sol_tsuite_fail(sol_tsuite const *tsuite,
-                int              *fail
-               )
+extern sol_erno sol_tsuite_fail(const sol_tsuite *tsuite,
+                                int *fail)
 {
 SOL_TRY:
                 /* check preconditions */
@@ -208,6 +210,9 @@ SOL_TRY:
         *fail = tsuite->fail;
 
 SOL_CATCH:
+                /* log current error code */
+        sol_log_erno(sol_erno_get());
+
 SOL_FINALLY:
                 /* wind up */
         return sol_erno_get();
@@ -219,10 +224,8 @@ SOL_FINALLY:
 /*
  *      sol_tsuite_total() - declared in sol/inc/test.h
  */
-extern sol_erno
-sol_tsuite_total(sol_tsuite const *tsuite,
-                 int              *total
-                )
+extern sol_erno sol_tsuite_total(const sol_tsuite *tsuite,
+                                 int *total)
 {
 SOL_TRY:
                 /* check preconditions */
@@ -232,6 +235,9 @@ SOL_TRY:
         *total = tsuite->total;
 
 SOL_CATCH:
+                /* log current error code */
+        sol_log_erno(sol_erno_get());
+
 SOL_FINALLY:
                 /* wind up */
         return sol_erno_get();
@@ -243,8 +249,7 @@ SOL_FINALLY:
 /*
  *      sol_tsuite_exec() - declared in sol/inc/test.h
  */
-extern sol_erno
-sol_tsuite_exec(sol_tsuite *tsuite)
+extern sol_erno sol_tsuite_exec(sol_tsuite *tsuite)
 {
         register int      i;
         auto     sol_erno erno;
@@ -270,6 +275,9 @@ SOL_TRY:
         }
 
 SOL_CATCH:
+                /* log current error code */
+        sol_log_erno(sol_erno_get());
+
 SOL_FINALLY:
                 /* wind up */
         return sol_erno_get();

--- a/test/runner.c
+++ b/test/runner.c
@@ -55,11 +55,12 @@ typedef sol_erno (suite)(sol_tlog *log,
 /*
  *      SUITE - enumerates test suite indices
  *        - SUITE_ERROR: exception handling module test suite
- *        - SUITE_TEST : unit test module test suite
- *        - SUITE_HINT : compiler hints module test
- *        - SUITE_ENV  : environment module test
- *        - SUITE_PTR  : pointer module test suite
- *        - SUITE_PTR2 : freestanding pointer module test suite
+ *        - SUITE_TEST: unit test module test suite
+ *        - SUITE_HINT: compiler hints module test
+ *        - SUITE_ENV: environment module test
+ *        - SUITE_PTR: pointer module test suite
+ *        - SUITE_PTR2: freestanding pointer module test suite
+ *        - SUITE_LOG: logging module test suite
  *        - SUITE_COUNT: count of test suites
  */
 typedef enum {
@@ -69,6 +70,7 @@ typedef enum {
         SUITE_ENV,
         SUITE_PTR,
         SUITE_PTR2,
+        SUITE_LOG,
         SUITE_COUNT
 } SUITE;
 
@@ -277,8 +279,7 @@ stat_sum(void)
 /*
  *      suite_init() - initialises test suites
  */
-static void
-suite_init(void)
+static void suite_init(void)
 {
                 /* register test suites */
         suite_hnd[SUITE_ERROR] = __sol_tsuite_error;
@@ -287,6 +288,7 @@ suite_init(void)
         suite_hnd[SUITE_ENV] = __sol_tests_env;
         suite_hnd[SUITE_PTR] = __sol_tests_ptr;
         suite_hnd[SUITE_PTR2] = __sol_tests_ptr2;
+        suite_hnd[SUITE_LOG] = __sol_tests_log;
 }
 
 

--- a/test/suite.h
+++ b/test/suite.h
@@ -109,6 +109,17 @@ extern sol_erno __sol_tests_ptr(sol_tlog *log,
 
 
 
+/*
+ *      __sol_tests_log() - test suite for the logging module
+ */
+extern sol_erno __sol_tests_log(sol_tlog *log,
+                                int *pass,
+                                int *fail,
+                                int *total);
+
+
+
+
 #endif /* !defined __SOL_LIBRARY_TEST_SUITES */
 
 

--- a/test/ts-log.c
+++ b/test/ts-log.c
@@ -1,0 +1,1038 @@
+/******************************************************************************
+ *                           SOL LIBRARY v1.0.0+41
+ *
+ * File: sol/test/ts-log.c
+ *
+ * Description:
+ *      This file is part of the internal quality checking of the Sol Library.
+ *      It implements the test suite for the logging module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* include required header files */
+#include "../inc/log.h"
+#include "../inc/libc.h"
+#include "../inc/ptr.h"
+#include "./suite.h"
+
+
+
+
+/*
+ *      mock_sleep() - mocks the sleep() function
+ *        - scale: sleep duration scale
+ */
+static void mock_sleep(int scale)
+{
+        const long TICK = 100000000;
+        auto int i;
+        auto int j;
+
+        for (i = 0; i < scale; i++) {
+                for (j = 0; j < TICK; j++); /* NOLINT */
+        }
+}
+
+
+
+
+/*
+ *      str_find() - searches for a substring
+ *        - what: substring to search
+ *        - where: string to search in
+ *
+ *      Return:
+ *        - 0 if @what is not found in @where
+ *        - 1 if @what is found in where
+ */
+static const int str_find(const char *needle, const char *haystack)
+{
+        const char *nitr = needle;
+        const char *hitr = haystack;
+        const char *hmark;
+        register int found = 0;
+
+                /* ensure both @needle and @haystack are valid strings */
+        if (!(nitr && hitr && *nitr && *hitr)) {
+                return 0;
+        }
+
+                /* loop through @haystack until @needle is found within it */
+        while (!found && *hitr) {
+                        /* locate position in @haystack that matches the first
+                         * character of @needle */
+                if (*hitr != *nitr) {
+                        hitr++;
+                        continue;
+                }
+
+                        /* mark current position of @haystack iterator, and
+                         * assume @needle is present in @haystack */
+                hmark = hitr;
+                found = 1;
+
+                        /* iterate through @haystack (from current position) and
+                         * @needle (from beginning) until our assumption that
+                         * @needle is present in @haystack is proven false */
+                while (*nitr) {
+                        if (!*hitr || (*hitr++ != *nitr++)) {
+                                found = 0;
+                                break;
+                        }
+                }
+
+                        /* continue looping after resetting @haystack iterator
+                         * to its last marked position and @needle iterator to
+                         * the beginning of @needle. */
+                hitr = hmark;
+                nitr = needle;
+                hitr++;
+        }
+
+                /* wind up */
+        return found;
+}
+
+
+
+
+/*
+ *      log_hasstr() - check log entry for string
+ *        - path: path to log file
+ *        - str: string to check
+ *        - line: line in which to check
+ *
+ *      Return:
+ *        - 0 if @str is not found
+ *        - 1 if @str is found
+ */
+static int log_hasstr(const char *path, const char *str, int line)
+{
+        const int LEN = 256;
+        auto FILE *log = SOL_PTR_NULL;
+        auto int rc = 0;
+        auto char bfr[LEN];
+        register int i;
+
+                /* open log file at @path and check whether @str exists as a
+                 * substring in the given @line; @path is assumed to be a valid
+                 * string */
+        if ((log = fopen(path, "r"))) { /* NOLINT */
+                for (i = 0; i < line; i++) {
+                        rc = fgets(bfr, LEN, log) ? str_find(str, bfr) : 0;
+                }
+
+                fclose(log);
+        }
+
+                /* wind up */
+        return rc;
+}
+
+
+
+
+/*
+ *      log_hasctm() - check log entry for current timestamp
+ *        - path: path to log file
+ *        - line: line in which to check
+ *
+ *      Return:
+ *        - 0 if current timestamp not found
+ *        - 1 if current timestamp found
+ */
+static int log_hasctm(const char *path, int line)
+{
+        const int NEWLN = 24;
+        auto time_t tm;
+        auto char *ctm;
+
+                /* get current timestamp and trim away trailing newline */
+        (void) time(&tm);
+        ctm = ctime(&tm);
+        ctm[NEWLN] = '\0';
+
+                /* check if current timestamp is in the log file at @path */
+        return log_hasstr(path, ctm, line);
+}
+
+
+
+
+/*
+ *      open_test1() - sol_log_open() unit test #1
+ */
+static sol_erno open_test1(void)
+{
+        #define OPEN_TEST1 "sol_log_open() throws SOL_ERNO_STR if @path is" \
+                           " a null pointer"
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(SOL_PTR_NULL));
+
+SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(sol_erno_get() == SOL_ERNO_STR
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        sol_log_close();
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      open_test2() - sol_log_open() unit test #2
+ */
+static sol_erno open_test2(void)
+{
+        #define OPEN_TEST2 "sol_log_open() throws SOL_ERNO_STR if @path is" \
+                           " a null string"
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(""));
+
+SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(sol_erno_get() == SOL_ERNO_STR
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        sol_log_close();
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      open_test3() - sol_log_open() unit test #3
+ */
+static sol_erno open_test3(void)
+{
+        #define OPEN_TEST3 "sol_log_open() creates the log file specified" \
+                           " by @path"
+        const char *PATH = "bld/dummy.test.log";
+        const int line = 1;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_trace("Hello!");
+        sol_log_close();
+
+                /* check test condition */
+        sol_assert (log_hasctm(PATH, line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "[T]", line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "Hello!", line), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      open_test4() - sol_log_open() unit test #4
+ */
+static sol_erno open_test4(void)
+{
+        #define OPEN_TEST4 "sol_log_open() throws SOL_ERNO_STATE if called" \
+                           " when a log file is already open"
+        const char *PATH = "bld/dummy.test.log";
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_try (sol_log_open(PATH));
+
+SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(sol_erno_get() == SOL_ERNO_STATE
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        sol_log_close();
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      open2_test1() - sol_log_open2() unit test #1
+ */
+static sol_erno open2_test1(void)
+{
+        #define OPEN2_TEST1 "sol_log_open2() throws SOL_ERNO_STR if @path is" \
+                            " a null pointer"
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open2(SOL_PTR_NULL, 0));
+
+SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(sol_erno_get() == SOL_ERNO_STR
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        sol_log_close();
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      open2_test2() - sol_log_open2() unit test #2
+ */
+static sol_erno open2_test2(void)
+{
+        #define OPEN2_TEST2 "sol_log_open2() throws SOL_ERNO_STR if @path is" \
+                            " a null string"
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open2("", 0));
+
+SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(sol_erno_get() == SOL_ERNO_STR
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        sol_log_close();
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      open2_test3() - sol_log_open2() unit test #3
+ */
+static sol_erno open2_test3(void)
+{
+        #define OPEN2_TEST3 "sol_log_open2() creates the log file specified" \
+                            " by @path when @flush is false"
+        const char *PATH = "bld/dummy.test.log";
+        const int line = 1;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open2(PATH, 0));
+        sol_log_trace("Hello!");
+        sol_log_close();
+
+                /* check test condition */
+        sol_assert (log_hasctm(PATH, line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "[T]", line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "Hello!", line), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      open2_test4() - sol_log_open2() unit test #4
+ */
+static sol_erno open2_test4(void)
+{
+        #define OPEN2_TEST4 "sol_log_open2() creates the log file specified" \
+                            " by @path when @flush is true"
+        const char *PATH = "bld/dummy.test.log";
+        const int line = 1;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open2(PATH, 1));
+        sol_log_trace("Hello!");
+        sol_log_close();
+
+                /* check test condition */
+        sol_assert (log_hasctm(PATH, line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "[T]", line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "Hello!", line), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      open2_test5() - sol_log_open2() unit test #5
+ */
+static sol_erno open2_test5(void)
+{
+        #define OPEN2_TEST5 "sol_log_open2() overwrites the entries in the" \
+                            " log file at @path when @flush is true"
+        const char *PATH = "bld/dummy.test.log";
+        const int line = 1;
+        const int sleep = 10;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open2(PATH, 1));
+        sol_log_trace("Hello!");
+        sol_log_close();
+        mock_sleep(sleep);
+        sol_try (sol_log_open2(PATH, 1));
+        sol_log_debug("Goodbye!");
+        sol_log_close();
+
+                /* check test condition */
+        sol_assert (log_hasctm(PATH, line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "[D]", line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "Goodbye!", line), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      open2_test6() - sol_log_open2() unit test #6
+ */
+static sol_erno open2_test6(void)
+{
+        #define OPEN2_TEST6 "sol_log_open2() preserves the entries in the" \
+                            " log file at @path when @flush is false"
+        const char *PATH = "bld/dummy.test.log";
+        const int line = 2;
+        const int sleep = 10;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open2(PATH, 1));
+        sol_log_trace("Hello!");
+        sol_log_close();
+        mock_sleep(sleep);
+        sol_try (sol_log_open2(PATH, 0));
+        sol_log_debug("Goodbye!");
+        sol_log_close();
+
+                /* check test condition */
+        sol_assert (log_hasctm(PATH, line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "[D]", line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "Goodbye!", line), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      open2_test7() - sol_log_open2() unit test #7
+ */
+static sol_erno open2_test7(void)
+{
+        #define OPEN2_TEST7 "sol_log_open2() throws SOL_ERNO_STATE if called" \
+                            " when a log file is already open"
+        const char *PATH = "bld/dummy.test.log";
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open2(PATH, 1));
+        sol_try (sol_log_open2(PATH, 0));
+
+SOL_CATCH:
+                /* check test condition */
+        sol_erno_set(sol_erno_get() == SOL_ERNO_STATE
+                     ? SOL_ERNO_NULL
+                     : SOL_ERNO_TEST);
+
+SOL_FINALLY:
+                /* wind up */
+        sol_log_close();
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      trace_test1() - sol_log_trace() unit test #1
+ */
+static sol_erno trace_test1(void)
+{
+        #define TRACE_TEST1 "sol_log_trace() writes a time-stamped trace" \
+                            " message correctly"
+        const char *PATH = "bld/dummy.test.log";
+        const char *msg = "This is a sample trace message.";
+        const int line = 1;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_trace(msg);
+        sol_log_close();
+
+                /* check test condition */
+        sol_assert (log_hasctm(PATH, line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "[T]", line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, msg, line), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      trace_test2() - sol_log_trace() unit test #2
+ */
+static sol_erno trace_test2(void)
+{
+        #define TRACE_TEST2 "sol_log_trace() performs a safe no-op if called" \
+                            " when no log file is open"
+
+                /* set up test scenario */
+        sol_log_trace("Dummy");
+        return SOL_ERNO_NULL;
+}
+
+
+
+
+/*
+ *      trace_test3() - sol_log_trace() unit test #3
+ */
+static sol_erno trace_test3(void)
+{
+        #define TRACE_TEST3 "sol_log_trace() performs a safe no-op if passed" \
+                            " a null pointer for @msg"
+        const char *PATH = "bld/dummy.test.log";
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_trace(SOL_PTR_NULL);
+        sol_log_close();
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      trace_test4() - sol_log_trace() unit test #4
+ */
+static sol_erno trace_test4(void)
+{
+        #define TRACE_TEST4 "sol_log_trace() performs a safe no-op if passed" \
+                            " a null string for @msg"
+        const char *PATH = "bld/dummy.test.log";
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_trace("");
+        sol_log_close();
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      debug_test1() - sol_log_debug() unit test #1
+ */
+static sol_erno debug_test1(void)
+{
+        #define DEBUG_TEST1 "sol_log_debug() writes a time-stamped debug" \
+                            " message correctly"
+        const char *PATH = "bld/dummy.test.log";
+        const char *msg = "This is a sample debug message.";
+        const int line = 1;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_debug(msg);
+        sol_log_close();
+
+                /* check test condition */
+        sol_assert (log_hasctm(PATH, line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "[D]", line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, msg, line), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      debug_test2() - sol_log_debug() unit test #2
+ */
+static sol_erno debug_test2(void)
+{
+        #define DEBUG_TEST2 "sol_log_debug() performs a safe no-op if called" \
+                            " when no log file is open"
+
+                /* set up test scenario */
+        sol_log_debug("Dummy");
+        return SOL_ERNO_NULL;
+}
+
+
+
+
+/*
+ *      debug_test3() - sol_log_debug() unit test #3
+ */
+static sol_erno debug_test3(void)
+{
+        #define DEBUG_TEST3 "sol_log_debug() performs a safe no-op if passed" \
+                            " a null pointer for @msg"
+        const char *PATH = "bld/dummy.test.log";
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_debug(SOL_PTR_NULL);
+        sol_log_close();
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      debug_test4() - sol_log_debug() unit test #4
+ */
+static sol_erno debug_test4(void)
+{
+        #define DEBUG_TEST4 "sol_log_debug() performs a safe no-op if passed" \
+                            " a null string for @msg"
+        const char *PATH = "bld/dummy.test.log";
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_debug("");
+        sol_log_close();
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      warn_test1() - sol_log_warn() unit test #1
+ */
+static sol_erno warn_test1(void)
+{
+        #define WARN_TEST1 "sol_log_warn() writes a time-stamped warning" \
+                           " message correctly"
+        const char *PATH = "bld/dummy.test.log";
+        const char *msg = "This is a sample warning message.";
+        const int line = 1;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_warn(msg);
+        sol_log_close();
+
+                /* check test condition */
+        sol_assert (log_hasctm(PATH, line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "[W]", line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, msg, line), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      warn_test2() - sol_log_warn() unit test #2
+ */
+static sol_erno warn_test2(void)
+{
+        #define WARN_TEST2 "sol_log_warn() performs a safe no-op if called" \
+                           " when no log file is open"
+
+                /* set up test scenario */
+        sol_log_warn("Dummy");
+        return SOL_ERNO_NULL;
+}
+
+
+
+
+/*
+ *      warn_test3() - sol_log_warn() unit test #3
+ */
+static sol_erno warn_test3(void)
+{
+        #define WARN_TEST3 "sol_log_warn() performs a safe no-op if passed" \
+                           " a null pointer for @msg"
+        const char *PATH = "bld/dummy.test.log";
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_warn(SOL_PTR_NULL);
+        sol_log_close();
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      warn_test3() - sol_log_warn() unit test #3
+ */
+static sol_erno warn_test4(void)
+{
+        #define WARN_TEST4 "sol_log_warn() performs a safe no-op if passed" \
+                           " a null string for @msg"
+        const char *PATH = "bld/dummy.test.log";
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_warn("");
+        sol_log_close();
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      error_test1() - sol_log_error() unit test #1
+ */
+static sol_erno error_test1(void)
+{
+        #define ERROR_TEST1 "sol_log_error() writes a time-stamped error" \
+                            " message correctly"
+        const char *PATH = "bld/dummy.test.log";
+        const char *msg = "This is a sample error message.";
+        const int line = 1;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_error(msg);
+        sol_log_close();
+
+                /* check test condition */
+        sol_assert (log_hasctm(PATH, line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "[E]", line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, msg, line), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      error_test2() - sol_log_error() unit test #2
+ */
+static sol_erno error_test2(void)
+{
+        #define ERROR_TEST2 "sol_log_error() performs a safe no-op if called" \
+                            " when no log file is open"
+
+                /* set up test scenario */
+        sol_log_error("Dummy");
+        return SOL_ERNO_NULL;
+}
+
+
+
+
+/*
+ *      error_test3() - sol_log_error() unit test #3
+ */
+static sol_erno error_test3(void)
+{
+        #define ERROR_TEST3 "sol_log_error() performs a safe no-op if passed" \
+                            " a null pointer for @msg"
+        const char *PATH = "bld/dummy.test.log";
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_error(SOL_PTR_NULL);
+        sol_log_close();
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      error_test4() - sol_log_error() unit test #4
+ */
+static sol_erno error_test4(void)
+{
+        #define ERROR_TEST4 "sol_log_error() performs a safe no-op if passed" \
+                            " a null string for @msg"
+        const char *PATH = "bld/dummy.test.log";
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_error("");
+        sol_log_close();
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      erno_test1() - sol_log_erno() unit test #1
+ */
+static sol_erno erno_test1(void)
+{
+        #define ERNO_TEST1 "sol_log_erno() writes a time-stamped error code" \
+                           " message correctly"
+        const char *PATH = "bld/dummy.test.log";
+        const char *msg = sol_erno_str(SOL_ERNO_STR);
+        const int line = 1;
+
+SOL_TRY:
+                /* set up test scenario */
+        sol_try (sol_log_open(PATH));
+        sol_log_erno(SOL_ERNO_STR);
+        sol_log_close();
+
+                /* check test condition */
+        sol_assert (log_hasctm(PATH, line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, "[E]", line), SOL_ERNO_TEST);
+        sol_assert (log_hasstr(PATH, msg, line), SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+/*
+ *      erno_test2() - sol_log_erno() unit test #2
+ */
+static sol_erno erno_test2(void)
+{
+        #define ERNO_TEST2 "sol_log_erno() performs a safe no-op if called" \
+                           " when no log file is open"
+
+                /* set up test scenario */
+        sol_log_erno(SOL_ERNO_STR);
+        return SOL_ERNO_NULL;
+}
+
+
+
+
+/*
+ *      __sol_tests_log() - declared in sol/test/suite.h
+ */
+extern sol_erno __sol_tests_log(sol_tlog *log,
+                                int *pass,
+                                int *fail,
+                                int *total)
+{
+        auto sol_tsuite __ts, *ts = &__ts;
+
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (log && pass && fail && total, SOL_ERNO_PTR);
+
+                /* initialise test suite */
+        sol_try (sol_tsuite_init2(ts, log));
+
+                /* register test cases */
+        sol_try (sol_tsuite_register(ts, &open_test1, OPEN_TEST1));
+        sol_try (sol_tsuite_register(ts, &open_test2, OPEN_TEST2));
+        sol_try (sol_tsuite_register(ts, &open_test3, OPEN_TEST3));
+        sol_try (sol_tsuite_register(ts, &open_test4, OPEN_TEST4));
+        sol_try (sol_tsuite_register(ts, &open2_test1, OPEN2_TEST1));
+        sol_try (sol_tsuite_register(ts, &open2_test2, OPEN2_TEST2));
+        sol_try (sol_tsuite_register(ts, &open2_test3, OPEN2_TEST3));
+        sol_try (sol_tsuite_register(ts, &open2_test4, OPEN2_TEST4));
+        sol_try (sol_tsuite_register(ts, &open2_test5, OPEN2_TEST5));
+        sol_try (sol_tsuite_register(ts, &open2_test6, OPEN2_TEST6));
+        sol_try (sol_tsuite_register(ts, &open2_test7, OPEN2_TEST7));
+        sol_try (sol_tsuite_register(ts, &trace_test1, TRACE_TEST1));
+        sol_try (sol_tsuite_register(ts, &trace_test2, TRACE_TEST2));
+        sol_try (sol_tsuite_register(ts, &trace_test3, TRACE_TEST3));
+        sol_try (sol_tsuite_register(ts, &trace_test4, TRACE_TEST4));
+        sol_try (sol_tsuite_register(ts, &debug_test1, DEBUG_TEST1));
+        sol_try (sol_tsuite_register(ts, &debug_test2, DEBUG_TEST2));
+        sol_try (sol_tsuite_register(ts, &debug_test3, DEBUG_TEST3));
+        sol_try (sol_tsuite_register(ts, &debug_test4, DEBUG_TEST4));
+        sol_try (sol_tsuite_register(ts, &warn_test1, WARN_TEST1));
+        sol_try (sol_tsuite_register(ts, &warn_test2, WARN_TEST2));
+        sol_try (sol_tsuite_register(ts, &warn_test3, WARN_TEST3));
+        sol_try (sol_tsuite_register(ts, &warn_test4, WARN_TEST4));
+        sol_try (sol_tsuite_register(ts, &error_test1, ERROR_TEST1));
+        sol_try (sol_tsuite_register(ts, &error_test2, ERROR_TEST2));
+        sol_try (sol_tsuite_register(ts, &error_test3, ERROR_TEST3));
+        sol_try (sol_tsuite_register(ts, &error_test4, ERROR_TEST4));
+        sol_try (sol_tsuite_register(ts, &erno_test1, ERNO_TEST1));
+        sol_try (sol_tsuite_register(ts, &erno_test2, ERNO_TEST2));
+
+                /* execute test cases */
+        sol_try (sol_tsuite_exec(ts));
+
+                /* report test counts */
+        sol_try (sol_tsuite_pass(ts, pass));
+        sol_try (sol_tsuite_fail(ts, fail));
+        sol_try (sol_tsuite_total(ts, total));
+
+SOL_CATCH:
+SOL_FINALLY:
+                /* wind up */
+        sol_tsuite_term(ts);
+        return sol_erno_get();
+}
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+


### PR DESCRIPTION
The logging module has been implemented with the following interface
functions/macros:
  * sol_log_open()
  * sol_log_open2()
  * sol_log_close()
  * sol_log_trace()
  * sol_log_debug()
  * sol_log_warn()
  * sol_log_error()
  * sol_log_erno()

In order to implement this interface, a libc compatiblity module has
also been introduced. This module provides a portable means to access
the required libc functions. Since the pointer module makes use of the
libc malloc()/free() functions if available, it has also been refactored
to make use of the newly introduced libc module.

Additionally, the compiler hint module has been enhanced with the
introduction of the sol_tls hint to mark thread local storage variables;
this resulted as a direct necessity of the logging module requiring the
use of a thread local global file stream.

The sol_erno_str() function has been introduced to the exception handling
module to generate the string representation of a sol_erno code; this
function is directly invoked by the sol_log_erno() wrapper macro.

29 unit tests have been added for the logging module, and the features
section of the Readme have been updated with the relevant details.

This pull request closes #42.