### PR TITLE
Add primitives module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,19 +46,20 @@ CMD_RUN = ./$(OUT_LD)
 
 
 # 	Set command options
-OPT_CC  = -c -fPIC -std=c99 -Wall -g -O0 -coverage
+OPT_CC  = -c -fPIC -std=c99 -Wall -Wextra -g -O0 -coverage
 OPT_SO  = -shared -g -O0 -coverage
-OPT_LD  = -std=c99 -Wall -g -O0 -coverage
+OPT_LD  = -std=c99 -Wall -Wextra -g -O0 -coverage
 OPT_COV = -o $(DIR_BLD)
 
 
 
 
 # 	Set command inputs
-INP_SO  = $(DIR_BLD)/error.o $(DIR_BLD)/test.o $(DIR_BLD)/ptr.o $(DIR_BLD)/log.o
+INP_SO  = $(DIR_BLD)/error.o $(DIR_BLD)/test.o $(DIR_BLD)/ptr.o \
+	  $(DIR_BLD)/log.o $(DIR_BLD)/prim.o
 INP_LD  = $(DIR_TEST)/runner.c $(DIR_TEST)/ts-error.c $(DIR_TEST)/ts-test.c \
 	  $(DIR_TEST)/ts-hint.c $(DIR_TEST)/ts-env.c $(DIR_TEST)/ts-ptr.c   \
-	  $(DIR_TEST)/ts-ptr2.c $(DIR_TEST)/ts-log.o
+	  $(DIR_TEST)/ts-ptr2.c $(DIR_TEST)/ts-log.o $(DIR_TEST)/ts-prim.o
 INP_COV = $(DIR_BLD)/error.gcda $(DIR_BLD)/test.gcda $(DIR_BLD)/ptr.gcda \
 	  $(DIR_BLD)/log.gcda
 INP_RUN = $(DIR_BLD)/test.log

--- a/inc/env.h
+++ b/inc/env.h
@@ -34,30 +34,93 @@
 
 
 /*
- *      SOL_ENV_CC - enumerates supported C compilers
- *        - SOL_ENV_CC_GNUC : GNU C or GNU C compatible compiler
+ * Interface: compiler
+ *
+ * Synopsis:
+ *      #include "sol/inc/env.h"
+ *
+ *      SOL_ENV_CC;
+ *      SOL_ENV_CC_GNUC;
+ *      SOL_ENV_CC_CLANG;
+ *      SOL_ENV_CC sol_env_cc(void);
+ *
+ * Description:
+ *      The compiler interface of the Environment Module of the Sol Library
+ *      provides a mechanism for client code to determine at compile time the
+ *      compiler being used.
+ *
+ *      The SOL_ENV_CC family of symbolic constants enumerate the compilers
+ *      recognised and supported by the Sol Library. Currently, only GNU C and
+ *      CLang compilers are supported directly, and GNU C compatible compilers
+ *      indirectly. This is expected to be adequate as far as portability is
+ *      concerned, as GNU C is the most widely ported C compiler. However, in
+ *      future, support for other compilers, including MSVC, **may** be
+ *      introduced if there is adequate reason to do so.
+ *
+ *      Accordingly, the supported compilers are represented by the SOL_ENV_CC
+ *      family of symbolic constants as follows:
+ *        - SOL_ENV_CC_GNUC: GNU C or GNU C compatible compiler
  *        - SOL_ENV_CC_CLANG: CLang front-end of LLVM compiler
  *
- *      The SOL_ENV_CC type enumerates the C compilers that are supported by the
- *      Sol Library. The constants enumerated by this type are returned by the
- *      sol_env_cc() macro (defined below) in order to indicate the C compiler
- *      being used at compile-time.
+ *      The sol_env_cc() macro determines at compile-time the C compiler that is
+ *      being used. This macro returns one of the SOL_ENV_CC family of constants
+ *      as appropriate.
  *
- *      Currently, only GNU C and CLang compilers are supported directly, and
- *      GNU C compatible compilers indirectly. This is expected to be adequate
- *      as far as portability is concerned, as GNU C is the most widely ported C
- *      compiler. However, in future, support for other compilers, including
- *      MSVC, *may* be introduced if there is adequate reason to do so.
+ * Notes:
+ *      The SOL_ENV_CC family of symbolic constants are defined as such, and not
+ *      as an enumeration, so that they may be used to perform relevant
+ *      pre-compilation checks at file scope outside any function body.
+ *
+ *      In case a compiler other than those recognised and supported by the Sol
+ *      Library is used, then the sol_env_cc() macro raises a compiler error.
  */
-#define SOL_ENV_CC       int
-#define SOL_ENV_CC_GNUC  (0)
+
+#define SOL_ENV_CC int
+#define SOL_ENV_CC_GNUC (0)
 #define SOL_ENV_CC_CLANG (1)
+
+#if (defined __GNUC__)
+#       define sol_env_cc() SOL_ENV_CC_GNUC
+#elif (defined __clang__)
+#       define sol_env_cc() SOL_ENV_CC_CLANG
+#else
+#       error sol_env_cc(): unsupported C compiler
+#endif
 
 
 
 
 /*
- *      SOL_ENV_STDC - enumerates supported C language standards
+ * Interface: C dialect
+ *
+ * Synopsis:
+ *      #include "sol/inc/env.h"
+ *
+ *      SOL_ENV_STDC
+ *      SOL_ENV_STDC_C89
+ *      SOL_ENV_STDC_C90
+ *      SOL_ENV_STDC_C94
+ *      SOL_ENV_STDC_C99
+ *      SOL_ENV_STDC_C11
+ *      SOL_ENV_STDC_C18
+ *      SOL_ENV_STDC sol_env_stdc(void);
+ *
+ * Description:
+ *      The C dialect interface of the Environment Module of the Sol Library
+ *      provides a mechanism for client code to determine at compile time the
+ *      standard C dialect being used.
+ *
+ *      The SOL_ENV_STDC family of symbolic constants enumerate the standard C
+ *      language dialects recognised and supported by the Sol Library. The Sol
+ *      Library is designed to be backward-compatible with the C89 standard,
+ *      while taking advantage of some of the new features introduced by the
+ *      modern standards. Backward-compatibility with the C89 standard ensures
+ *      maximum portability; dialects predating the C89 standard are not
+ *      considered, as they are fairly archaic and limited only to deprecated
+ *      compilers.
+ *
+ *      The supported C dialects are represented by the SOL_ENV_STDC symbolic
+ *      constants as follows:
  *        - SOL_ENV_STDC_C89: C89 standard
  *        - SOL_ENV_STDC_C90: C90 standard
  *        - SOL_ENV_STDC_C94: C94 standard
@@ -65,19 +128,20 @@
  *        - SOL_ENV_STDC_C11: C11 standard
  *        - SOL_ENV_STDC_C18: C18 standard
  *
- *      The SOL_ENV_STDC type enumerates the C language standards that are
- *      supported by the Sol Library. The constants enumerated by this type are
- *      used by the sol_env_stdc() macro (defined below) in order to indicate
- *      the compile-time C standard being used.
+ *      The sol_env_stdc() macro determines at compile-time the standard C
+ *      dialect being used for compilation, and returns one of the SOL_ENV_STDC
+ *      family of symbolic constants as appropriate
  *
- *      The Sol Library is designed to be backward-compatible with the C89
- *      standard, while taking advantage of some of the new features introduced
- *      by the modern standards. Backward-compatiblity with the C89 standard
- *      ensures maximum portability; dialects predating the C89 standard are not
- *      considered, as they are fairly archaic and limited only to deprecated
- *      compilers.
+ * Notes:
+ *      The SOL_ENV_STDC family of symbolic constants are defined as such, and
+ *      not as an enumeration, so that they may be used to perform relevant
+ *      pre-compilation checks at file scope outside any function body.
+ *
+ *      In case a C dialect other than those recognised and supported by the Sol
+ *      Library is used, then the sol_env_stdc() macro raises a compiler error.
  */
-#define SOL_ENV_STDC     int
+
+#define SOL_ENV_STDC int
 #define SOL_ENV_STDC_C89 (0)
 #define SOL_ENV_STDC_C90 (1)
 #define SOL_ENV_STDC_C94 (2)
@@ -85,115 +149,6 @@
 #define SOL_ENV_STDC_C11 (4)
 #define SOL_ENV_STDC_C18 (5)
 
-
-
-
-/*
- *      SOL_ENV_HOST - enumerates supported host platforms
- *        - SOL_ENV_HOST_NONE   : Freestanding environment
- *        - SOL_ENV_HOST_ANDROID: Android
- *        - SOL_ENV_HOST_LINUX  : All other flavours of Linux
- *        - SOL_ENV_HOST_CYGWIN : Cygwin on Microsoft Windows
- *        - SOL_ENV_HOST_BSD    : All BSD variants
- *        - SOL_ENV_HOST_HPUX   : HP-UX
- *        - SOL_ENV_HOST_AIX    : IBM AIX
- *        - SOL_ENV_HOST_IOS    : Apple iOS
- *        - SOL_ENV_HOST_OSX    : Apple OSX
- *        - SOL_ENV_HOST_SOLARIS: Oracle Solaris / Open Indiana
- *
- *      The SOL_ENV_HOST type enumerates the host platforms that are supported
- *      by the Sol Library. The constants enumerated by this type are returned
- *      by the sol_env_host() macro (defined below) in order to indicate the
- *      compile-time host platform.
- *
- *      The Sol Library has been designed to support both freestanding and POSIX
- *      compliant hosted platforms; however, as of now, only the Linux platform
- *      has been tested, and support for the others being assumed based on these
- *      tests.
- */
-#define SOL_ENV_HOST         int
-#define SOL_ENV_HOST_NONE    (0)
-#define SOL_ENV_HOST_ANDROID (1)
-#define SOL_ENV_HOST_LINUX   (2)
-#define SOL_ENV_HOST_CYGWIN  (3)
-#define SOL_ENV_HOST_BSD     (4)
-#define SOL_ENV_HOST_HPUX    (5)
-#define SOL_ENV_HOST_AIX     (6)
-#define SOL_ENV_HOST_IOS     (7)
-#define SOL_ENV_HOST_OSX     (8)
-#define SOL_ENV_HOST_SOLARIS (9)
-
-
-
-
-/*
- *      SOL_ENV_ARCH - enumerates supported CPU architectures
- *        - SOL_ENV_ARCH_X68  : 32-bit x86 processor
- *        - SOL_ENV_ARCH_AMD64: 64-bit x86_64 processor
- *        - SOL_ENV_ARCH_IA64 : 64-bit Itanium processor
- *        - SOL_ENV_ARCH_ARM  : 32-bit ARM processor
- *        - SOL_ENV_ARCH_ARM64: 64-bit ARM64 processor
- *
- *      The SOL_ENV_ARCH type enumerates the CPU architectures supported by the
- *      Sol Library. The constants enumerated by this type are returned by the
- *      sol_env_arch() macro (defined below) in order to indicate the processor
- *      architecture at compile-time.
- *
- *      The Sol Library currently supports the 32-bit ARM and x86 processor
- *      families, and the 64-bit ARM64, x86_64 and Itanium family of processors.
- *      The Sol Library has been tested on the x86_64 architecture, and support
- *      for the others is assumed based on these tests.
- */
-#define SOL_ENV_ARCH       int
-#define SOL_ENV_ARCH_X86   (0)
-#define SOL_ENV_ARCH_AMD64 (1)
-#define SOL_ENV_ARCH_IA64  (2)
-#define SOL_ENV_ARCH_ARM   (3)
-#define SOL_ENV_ARCH_ARM64 (4)
-
-
-
-
-/*
- *      sol_env_cc() - determines C compiler at compile-time
- *
- *      The sol_env_cc() macro determines at compile-time the C compiler that is
- *      being used. This macro returns one of the constants enumerated by the
- *      SOL_ENV_CC type as appropriate. A compile-time error is raised in case
- *      an unsupported compiler is detected.
- *
- *      Return:
- *        - SOL_ENV_CC_GNUC if GNU C or GNU C compatible compiler detected
- *        - SOL_ENV_CC_CLANG if CLang compiler detected
- */
-#if (defined __GNUC__)
-#       define sol_env_cc() SOL_ENV_CC_GNUC
-#elif (defined __clang__)
-#       define sol_env_cc() SOL_ENV_CC_CLANG
-#else
-#       error "[!] sol_env_cc() error: unsupported C compiler"
-#endif
-
-
-
-
-/*
- *      sol_env_stdc() - determines compile-time C language standard
- *
- *      The sol_env_stdc() macro determines at compile-time the C language
- *      standard that is being used. This macro returns one of the constants
- *      enumerated by the SOL_ENV_STDC type as appropriate. A compile-time error
- *      is raised in case an unsupported standard is detected.
- *
- *      Return:
- *        - SOL_ENV_STDC_C89 if C89 standard detected
- *        - SOL_ENV_STDC_C90 if C90 standard detected
- *        - SOL_ENV_STDC_C94 if C94 standard detected
- *        - SOL_ENV_STDC_C99 if C99 standard detected
- *        - SOL_ENV_STDC_C11 if C11 standard detected
- *        - SOL_ENV_STDC_C18 if C18 standard detected
- *
- */
 #if (defined __STDC__)
 #       if (defined __STDC_VERSION__)
 #               if (__STDC_VERSION__ >= 201710L)
@@ -211,32 +166,67 @@
 #               define sol_env_stdc() SOL_ENV_STDC_C89
 #       endif
 #else
-#       error "[!] sol_env_stdc() error: unsupported C language standard"
+#       error sol_env_stdc(): unsupported C language standard
 #endif
 
 
 
 
-/*
- *      sol_env_host() - determines compile-time host platform
- *
- *      The sol_env_host() macro determines at compile-time the host platform
- *      that is being used. This macro returns one of the constants enumerated
- *      by the SOL_ENV_HOST type as appropriate. A compile-time error is raised
- *      in case an unsupported host is detected.
- *
- *      Return:
- *        - SOL_ENV_HOST_NONE if freestanding environment detected
- *        - SOL_ENV_HOST_ANDROID if Android detected
- *        - SOL_ENV_HOST_LINUX if other Linux flavour detected
- *        - SOL_ENV_HOST_CYGWIN if Cygwin on Microsoft Windows detected
- *        - SOL_ENV_HOST_BSD if a BSD variant detected
- *        - SOL_ENV_HOST_HPUX if HP-UX detected
- *        - SOL_ENV_HOST_AIX if IBM AIX detected
- *        - SOL_ENV_HOST_IOS if Apple iOS detected
- *        - SOL_ENV_HOST_OSX if Apple OSX detected
- *        - SOL_ENV_HOST_SOLARIS if Oracle Solaris / Open Indiana detected
- */
+        /*
+         * SOL_ENV_HOST - enumerates supported host platforms
+         *   - SOL_ENV_HOST_NONE: Freestanding environment
+         *   - SOL_ENV_HOST_ANDROID: Android
+         *   - SOL_ENV_HOST_LINUX: All other flavours of Linux
+         *   - SOL_ENV_HOST_CYGWIN: Cygwin on Microsoft Windows
+         *   - SOL_ENV_HOST_BSD: All BSD variants
+         *   - SOL_ENV_HOST_HPUX: HP-UX
+         *   - SOL_ENV_HOST_AIX: IBM AIX
+         *   - SOL_ENV_HOST_IOS: Apple iOS
+         *   - SOL_ENV_HOST_OSX: Apple OSX
+         *   - SOL_ENV_HOST_SOLARIS: Oracle Solaris / Open Indiana
+         *
+         * The SOL_ENV_HOST type enumerates the host platforms that are
+         * supported by the Sol Library. The constants enumerated by this type
+         * are returned by the sol_env_host() macro (defined below) in order to
+         * indicate the compile-time host platform.
+         *
+         * The Sol Library has been designed to support both freestanding and
+         * POSIX compliant hosted platforms; however, as of now, only the Linux
+         * platform has been tested, and support for the others being assumed
+         * based on these tests.
+         */
+#define SOL_ENV_HOST int
+#define SOL_ENV_HOST_NONE (0)
+#define SOL_ENV_HOST_ANDROID (1)
+#define SOL_ENV_HOST_LINUX (2)
+#define SOL_ENV_HOST_CYGWIN (3)
+#define SOL_ENV_HOST_BSD (4)
+#define SOL_ENV_HOST_HPUX (5)
+#define SOL_ENV_HOST_AIX (6)
+#define SOL_ENV_HOST_IOS (7)
+#define SOL_ENV_HOST_OSX (8)
+#define SOL_ENV_HOST_SOLARIS (9)
+
+        /*
+         * sol_env_host() - determines compile-time host platform
+         *
+         * The sol_env_host() macro determines at compile-time the host platform
+         * that is being used. This macro returns one of the constants
+         * enumerated by the SOL_ENV_HOST type as appropriate. A compile-time
+         * error is raised in case an unsupported host is detected.
+         *
+         * Return:
+         *   - SOL_ENV_HOST_NONE if freestanding environment detected
+         *   - SOL_ENV_HOST_ANDROID if Android detected
+         *   - SOL_ENV_HOST_LINUX if other Linux flavour detected
+         *   - SOL_ENV_HOST_CYGWIN if Cygwin on Microsoft Windows detected
+         *   - SOL_ENV_HOST_BSD if a BSD variant detected
+         *   - SOL_ENV_HOST_HPUX if HP-UX detected
+         *   - SOL_ENV_HOST_AIX if IBM AIX detected
+         *   - SOL_ENV_HOST_IOS if Apple iOS detected
+         *   - SOL_ENV_HOST_OSX if Apple OSX detected
+         *   - SOL_ENV_HOST_SOLARIS if Oracle Solaris / Open Indiana detected
+         */
 #if (defined __CYGWIN__)
 #       define sol_env_host() (SOL_ENV_HOST_CYGWIN)
 #elif (defined __ANDROID__)
@@ -256,43 +246,70 @@
 #       endif
 #elif (defined __APPLE__ && defined __MACH__)
 #       include <TargetConditionals.h>
-#       if (1 == TARGET_IPHONE_SIMULATOR || 1 == TARGET_OS_IPHONE)
+#       if (TARGET_IPHONE_SIMULATOR == 1 || TARGET_OS_IPHONE == 1)
 #               define sol_env_host() (SOL_ENV_HOST_IOS)
-#       elif (1 == TARGET_OS_MAC)
+#       elif (TARGET_OS_MAC == 1)
 #               define sol_env_host() (SOL_ENV_HOST_OSX)
 #       endif
 #elif (defined __STDC_HOSTED__)
-#       if (0 == __STDC_HOSTED__)
+#       if (__STDC_HOSTED__ == 0)
 #               define sol_env_host() (SOL_ENV_HOST_NONE)
 #       endif
 #else
-#       error "[!] sol_env_host() error: unsupported host platform"
+#       error sol_env_host(): unsupported host platform
 #endif
 
 
 
 
-/*
- *      sol_env_arch() - determines compile-time CPU architecture
- *
- *      The sol_env_arch() macro determines at compile-time the processor
- *      architecture that is being used. This macro returns one of the constants
- *      enumerated by the SOL_ENV_ARCH type as appropriate. A compile-time error
- *      is raised in case an unsupported architecture is detected.
- *
- *      Return:
- *        - SOL_ENV_ARCH_X68 if 32-bit x86 processor detected
- *        - SOL_ENV_ARCH_AMD64 if 64-bit x86_64 processor detected
- *        - SOL_ENV_ARCH_IA64 if 64-bit Itanium processor detected
- *        - SOL_ENV_ARCH_ARM if 32-bit ARM processor detected
- *        - SOL_ENV_ARCH_ARM64 if 64-bit ARM64 processor detected
- */
-#if (defined __amd64__ || defined __amd64                          \
+        /*
+         * SOL_ENV_ARCH - enumerates supported CPU architectures
+         *   - SOL_ENV_ARCH_X68: 32-bit x86 processor
+         *   - SOL_ENV_ARCH_AMD64: 64-bit x86_64 processor
+         *   - SOL_ENV_ARCH_IA64: 64-bit Itanium processor
+         *   - SOL_ENV_ARCH_ARM: 32-bit ARM processor
+         *   - SOL_ENV_ARCH_ARM64: 64-bit ARM64 processor
+         *
+         * The SOL_ENV_ARCH type enumerates the CPU architectures supported by
+         * the Sol Library. The constants enumerated by this type are returned
+         * by the sol_env_arch() macro (defined below) in order to indicate the
+         * processor architecture at compile-time.
+         *
+         * The Sol Library currently supports the 32-bit ARM and x86 processor
+         * families, and the 64-bit ARM64, x86_64 and Itanium family of
+         * processors. The Sol Library has been tested on the x86_64
+         * architecture, and support for the others is assumed based on these
+         * tests.
+         */
+#define SOL_ENV_ARCH int
+#define SOL_ENV_ARCH_X86 (0)
+#define SOL_ENV_ARCH_AMD64 (1)
+#define SOL_ENV_ARCH_IA64 (2)
+#define SOL_ENV_ARCH_ARM (3)
+#define SOL_ENV_ARCH_ARM64 (4)
+
+        /*
+         * sol_env_arch() - determines compile-time CPU architecture
+         *
+         * The sol_env_arch() macro determines at compile-time the processor
+         * architecture that is being used. This macro returns one of the
+         * constants enumerated by the SOL_ENV_ARCH type as appropriate. A
+         * compile-time error is raised in case an unsupported architecture is
+         * detected.
+         *
+         * Return:
+         *   - SOL_ENV_ARCH_X68 if 32-bit x86 processor detected
+         *   - SOL_ENV_ARCH_AMD64 if 64-bit x86_64 processor detected
+         *   - SOL_ENV_ARCH_IA64 if 64-bit Itanium processor detected
+         *   - SOL_ENV_ARCH_ARM if 32-bit ARM processor detected
+         *   - SOL_ENV_ARCH_ARM64 if 64-bit ARM64 processor detected
+         */
+#if (defined __amd64__ || defined __amd64                           \
      || defined __x86_64__  || defined __x86_64)
 #       define sol_env_arch() SOL_ENV_ARCH_AMD64
 #elif (defined __ia64__ || defined __IA64__ || defined _IA64)
 #       define sol_env_arch() SOL_ENV_ARCH_IA64
-#elif (defined i386 || defined __i386 || defined __i386__          \
+#elif (defined i386 || defined __i386 || defined __i386__           \
        || defined __i486__ || defined __i586__ || defined __i686__)
 #       define sol_env_arch() SOL_ENV_ARCH_X86
 #elif (defined __arm__ || defined __thumb__)
@@ -300,11 +317,8 @@
 #elif (defined __aarch64__)
 #       define sol_env_arch() SOL_ENV_ARCH_ARM64
 #else
-#       error "[!] sol_env_arch() error: unsupported architecture"
+#       error sol_env_arch(): unsupported architecture
 #endif
-
-
-
 
 /*
  *      sol_env_wordsz() - determines compile-time native word size
@@ -336,31 +350,43 @@
 
 
 /*
- *      sol_env_file() - introspects current file name
+ * Interface: introspection
+ *
+ * Synopsis:
+ *      #include "sol/inc/env.h"
+ *
+ *      const char* sol_env_file(void);
+ *      const char* sol_env_func(void);
+ *      int sol_env_line(void);
+ *
+ * Description:
+ *      The introspection interface of the Environment Module of the Sol Library
+ *      provides a mechanism for client code to determine at compile time the
+ *      current point of execution.
+ *
+ *      The sol_env_file() macro returns the name of the source file where the
+ *      current point of execution resides. The sol_env_func() macro returns the
+ *      name of the function where the current point of execution resides. The
+ *      sol_env_line() macro returns the line number where the current point of
+ *      execution resides.
+ *
+ * Notes:
+ *      The sol_env_func() macro is available only if C99 and above is used for
+ *      compilation; in case C89 or C90 is used, then sol_env_func() returns a
+ *      string set to "<unknown>" and issues a compiler warning.
  */
+
 #define sol_env_file() __FILE__
 
-
-
-
-/*
- *      sol_env_func() - introspects current function name
- */
 #if (sol_env_stdc() >= SOL_ENV_STDC_C99)
 #       define sol_env_func() __func__
 #elif (sol_env_cc() == SOL_ENV_CC_GNUC || sol_env_cc() == SOL_ENV_CC_CLANG)
 #       define sol_env_func() __FUNCTION__
 #else
 #       define sol_env_func() "<unknown>"
-#       warning "[!] sol_env_func() warning: unable to determine function name"
+#       warning sol_env_func(): unable to determine function name
 #endif
 
-
-
-
-/*
- *      sol_env_line() - introspects current line number
- */
 #define sol_env_line() __LINE__
 
 

--- a/inc/error.h
+++ b/inc/error.h
@@ -34,8 +34,8 @@
 
 
         /* include required header files */
-#include "./hint.h"
-#include <stddef.h>
+#include "hint.h"
+#include "prim.h"
 
 
 
@@ -50,7 +50,7 @@
  *      type can take advantage of the exception handling features provided by
  *      this module.
  */
-typedef size_t sol_erno;
+typedef sol_word sol_erno;
 
 
 
@@ -232,6 +232,17 @@ typedef size_t sol_erno;
 
 
 
+/*
+ *      sol_erno_str() - stringifies error code
+ *        - erno: error code
+ *
+ *      The sol_erno_str() function generates the string representation of a
+ *      sol_erno error code @erno. This function represents @erno in hexadecimal
+ *      notation prefixed with a "0x".
+ *
+ *      Return:
+ *        - string representation of @erno
+ */
 extern const char *sol_erno_str(sol_erno erno);
 
 

--- a/inc/libc.h
+++ b/inc/libc.h
@@ -39,6 +39,7 @@
 #       include <stdio.h>
 #       include <stdlib.h>
 #       include <time.h>
+#       include <math.h>
 #endif
 
 
@@ -197,6 +198,19 @@
 #       define SOL_LIBC_CTIME_DEFINED
 #endif
 
+
+
+
+/*
+ *      SOL_LIBC_FABS_DEFINED - math.h fabs() defined
+ */
+#if (sol_env_host() == SOL_ENV_HOST_NONE)
+#       if (!defined SOL_LIBC_FABS_DEFINED)
+#               error "[!] Sol libc error: fabs() not defined"
+#       endif
+#else
+#       define SOL_LIBC_FABS_DEFINED
+#endif
 
 
 

--- a/inc/prim.h
+++ b/inc/prim.h
@@ -1,0 +1,842 @@
+/******************************************************************************
+ *                           SOL LIBRARY v0.1.0+41
+ *
+ * File: sol/inc/prim.h
+ *
+ * Description:
+ *      This file is part of the API of the Sol Library. It declares the
+ *      interface of the primitives module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* define header guard */
+#if (!defined __SOL_PRIMITIVES_MODULE)
+#define __SOL_PRIMITIVES_MODULE
+
+
+
+
+        /* include required header files; the stdbool.h and stdint.h header
+         * files are used in case a C99 environment is available */
+#include "./env.h"
+#include "./hint.h"
+#include <float.h>
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       include <stdbool.h>
+#       include <stdint.h>
+#       include <inttypes.h>
+#endif
+
+
+
+
+        /*
+         * SOL_BOOL - a Boolean value
+         *   - SOL_BOOL_FALSE: Boolean value 'False'
+         *   - SOL_BOOL_TRUE: Boolean value 'True'
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef bool SOL_BOOL;
+#       define SOL_BOOL_FALSE (false)
+#       define SOL_BOOL_TRUE (true)
+#else
+        typedef int SOL_BOOL;
+#       define SOL_BOOL_FALSE ((SOL_BOOL) 0)
+#       define SOL_BOOL_TRUE ((SOL_BOOL) 1)
+#endif
+
+        /*
+         * SOL_BOOL_FMT - format specifier for SOL_BOOL
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_BOOL_FMT PRId32
+#else
+#       define SOL_BOOL_FMT "d"
+#endif
+
+
+
+
+        /*
+         * sol_w8 - 8-bit word
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef uint8_t sol_w8;
+#else
+        typedef unsigned char sol_w8;
+#endif
+
+        /*
+         * SOL_W8_NULL: sol_w8 null value
+         */
+#define SOL_W8_NULL ((sol_w8) 0x0)
+
+        /*
+         * SOL_W8_MIN - minimum value of sol_w8
+         */
+#define SOL_W8_MIN ((sol_w8) 0x0)
+
+        /*
+         * SOL_W8_MAX - maximum value of sol_w8
+         */
+#define SOL_W8_MAX ((sol_w8) 0xFF)
+
+        /*
+         * SOL_W8_FMT - format specifier for sol_w8
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_W8_FMT PRIu32
+#else
+#       define SOL_W8_FMT "u"
+#endif
+
+
+
+
+        /*
+         * sol_w16 - 16-bit word
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef uint16_t sol_w16;
+#else
+        typedef unsigned short int sol_w16;
+#endif
+
+        /*
+         * SOL_W16_NULL: sol_w16 null value
+         */
+#define SOL_W16_NULL ((sol_w16) 0x0)
+
+        /*
+         * SOL_W16_MIN - minimum value of sol_w16
+         */
+#define SOL_W16_MIN ((sol_w16) 0x0)
+
+        /*
+         * SOL_W16_MAX - maximum value of sol_w16
+         */
+#define SOL_W16_MAX ((sol_w16) 0xFFFF)
+
+        /*
+         * SOL_W16_FMT - format specifier for sol_w16
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_W16_FMT PRIu32
+#else
+#       define SOL_W16_FMT "u"
+#endif
+
+
+
+
+        /*
+         * sol_w32 - 32-bit word
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef uint32_t sol_w32;
+#else
+        typedef unsigned int sol_w32;
+#endif
+
+        /*
+         * SOL_W32_NULL: sol_w32 null value
+         */
+#define SOL_W32_NULL ((sol_w32) 0x0)
+
+        /*
+         * SOL_W32_MIN - minimum value of sol_w32
+         */
+#define SOL_W32_MIN ((sol_w32) 0x0)
+
+        /*
+         * SOL_W32_MAX - maximum value of sol_w32
+         */
+#define SOL_W32_MAX ((sol_w32) 0xFFFFFFFF)
+
+        /*
+         * SOL_W32_FMT - format specifier for sol_w32
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_W32_FMT PRIu32
+#else
+#       define SOL_W32_FMT "u"
+#endif
+
+
+
+
+        /*
+         * sol_w64 - 64-bit word
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef uint64_t sol_w64;
+#elif (sol_env_wordsz() == 64)
+        typedef unsigned long sol_w64;
+#else
+#       error sol_w64: 64-bit types not supported in current environment
+#endif
+
+        /*
+         * SOL_W64_NULL: sol_w64 null value
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99 || sol_env_wordsz() == 64)
+#       define SOL_W64_NULL ((sol_w64) 0x0)
+#else
+#       error SOL_W64_NULL: 64-bit types not supported in current environment
+#endif
+
+        /*
+         * SOL_W64_MIN - minimum value of sol_w64
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99 || sol_env_wordsz() == 64)
+#       define SOL_W64_MIN ((sol_w64) 0x0)
+#else
+#       error SOL_W64_MIN: 64-bit types not supported in current environment
+#endif
+
+        /*
+         * SOL_W64_MAX - maximum value of sol_w64
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99 || sol_env_wordsz() == 64)
+#       define SOL_W64_MAX ((sol_w32) 0xFFFFFFFFFFFFFFFF)
+#else
+#       error SOL_W64_MAX: 64-bit types not supported in current environment
+#endif
+
+        /*
+         * SOL_W64_FMT - format specifier for sol_w64
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_W64_FMT PRIu64
+#elif (sol_env_wordsz() == 64)
+#       define SOL_W64_FMT "lu"
+#else
+#       error SOL_W64_FMT: 64-bit types not supported in current environment
+#endif
+
+
+
+
+        /*
+         * sol_word - native size word
+         */
+#if (sol_env_wordsz() == 64)
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+                typedef uint_fast64_t sol_word;
+#       else
+                typedef sol_w64 sol_word;
+#       endif
+#else
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+                typedef uint_fast32_t sol_word;
+#       else
+                typedef sol_w32 sol_word;
+#       endif
+#endif
+
+        /*
+         * SOL_WORD_NULL - sol_word null value
+         */
+#define SOL_WORD_NULL ((sol_word) 0x0)
+
+        /*
+         * SOL_WORD_MIN - minimum value of sol_word
+         */
+#define SOL_WORD_MIN ((sol_word) 0x0)
+
+        /*
+         * SOL_WORD_MAX - maximum value of sol_word
+         */
+#if (sol_env_wordsz() == 64)
+#       define SOL_WORD_MAX SOL_W64_MAX
+#else
+#       define SOL_WORD_MAX SOL_W32_MAX
+#endif
+
+        /*
+         * SOL_WORD_FMT - format specifier for sol_word
+         */
+#if (sol_env_wordsz() == 64)
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#               define SOL_WORD_FMT PRIuFAST64
+#       else
+#               define SOL_WORD_FMT SOL_W64_FMT
+#       endif
+#else
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#               define SOL_WORD_FMT PRIuFAST32
+#       else
+#               define SOL_WORD_FMT SOL_W32_FMT
+#       endif
+#endif
+
+
+
+
+        /*
+         * sol_size - size value
+         */
+typedef sol_word sol_size;
+
+        /*
+         * SOL_SIZE_MIN - minimum value of sol_size
+         */
+#define SOL_SIZE_MIN SOL_WORD_MIN
+
+        /*
+         * SOL_SIZE_MAX - maximum value of sol_size
+         */
+#define SOL_SIZE_MAX SOL_WORD_MAX
+
+        /*
+         * SOL_SIZE_FMT - format specifier for sol_size
+         */
+#define SOL_SIZE_FMT SOL_WORD_FMT
+
+
+
+
+        /*
+         * sol_index - index value
+         */
+typedef sol_word sol_index;
+
+        /*
+         * SOL_INDEX_MIN - minimum value of sol_index
+         */
+#define SOL_INDEX_MIN SOL_WORD_MIN
+
+        /*
+         * SOL_INDEX_MAX - maximum value of sol_index
+         */
+#define SOL_INDEX_MAX SOL_WORD_MAX
+
+        /*
+         * SOL_INDEX_FMT - format specifier for sol_index
+         */
+#define SOL_INDEX_FMT SOL_WORD_FMT
+
+
+
+
+        /*
+         * sol_i8 - 8-bit signed integer
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef int8_t sol_i8;
+#else
+        typedef signed char sol_i8;
+#endif
+
+        /*
+         * SOL_I8_MIN - minimum value of sol_i8
+         */
+#define SOL_I8_MIN ((sol_i8) -127)
+
+        /*
+         * SOL_I8_MAX - maximum value of sol_i8
+         */
+#define SOL_I8_MAX ((sol_i8) 127)
+
+        /*
+         * SOL_I8_FMT - format specifier for sol_i8
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_I8_FMT PRId32
+#else
+#       define SOL_I8_FMT "d"
+#endif
+
+
+
+
+        /*
+         * sol_i16 - 16-bit signed integer
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef int16_t sol_i16;
+#else
+        typedef signed short int sol_i16;
+#endif
+
+        /*
+         * SOL_I16_MIN - minimum value of sol_i16
+         */
+#define SOL_I16_MIN ((sol_i16) -32767)
+
+        /*
+         * SOL_I16_MAX - maximum value of sol_i16
+         */
+#define SOL_I16_MAX ((sol_i16) 32767)
+
+        /*
+         * SOL_I16_FMT - format specifier for sol_i16
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_I16_FMT PRId32
+#else
+#       define SOL_I16_FMT "d"
+#endif
+
+
+
+
+        /*
+         * sol_i32 - 32-bit signed integer
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef int32_t sol_i32;
+#else
+        typedef signed int sol_i32;
+#endif
+
+        /*
+         * SOL_I32_MIN - minimum value of sol_i32
+         */
+#define SOL_I32_MIN ((sol_i32) -2147483647)
+
+        /*
+         * SOL_I32_MAX - maximum value of sol_i32
+         */
+#define SOL_I32_MAX ((sol_i32) 2147483647)
+
+        /*
+         * SOL_I32_FMT - format specifier for sol_i32
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_I32_FMT PRId32
+#else
+#       define SOL_I32_FMT "d"
+#endif
+
+
+
+
+        /*
+         * sol_i64 - 64-bit signed integer
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef int64_t sol_i64;
+#elif (sol_env_wordsz() == 64)
+        typedef signed long sol_i64;
+#else
+#       error sol_i64: 64-bit types not supported in current environment
+#endif
+
+        /*
+         * SOL_I64_MIN - minimum value of sol_i64
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99 || sol_env_wordsz() == 64)
+#       define SOL_I64_MIN ((sol_i64) -9223372036854775807)
+#else
+#       error SOL_I64_MIN: 64-bit types not supported in current environment
+#endif
+
+        /*
+         * SOL_I64_MAX - maximum value of sol_i64
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99 || sol_env_wordsz() == 64)
+#       define SOL_I64_MAX ((sol_i64) 9223372036854775807)
+#else
+#       error SOL_I64_MAX: 64-bit types not supported in current environment
+#endif
+
+        /*
+         * SOL_I64_FMT - format specifier for sol_i64
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_I64_FMT PRId64
+#elif (sol_env_wordsz() == 64)
+#       define SOL_I64_FMT "ld"
+#else
+#       error SOL_I64_FMT: 64-bt types not supported in current environment
+#endif
+
+
+
+
+        /*
+         * sol_int - native size signed integer
+         */
+#if (sol_env_wordsz() == 64)
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+                typedef int_fast64_t sol_int;
+#       else
+                typedef sol_i64 sol_int;
+#       endif
+#else
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+                typedef int_fast32_t sol_int;
+#       else
+                typedef sol_i32 sol_int;
+#       endif
+#endif
+
+        /*
+         * SOL_INT_MIN - minimum value of sol_int
+         */
+#if (sol_env_wordsz() == 64)
+#       define SOL_INT_MIN SOL_I64_MIN
+#else
+#       define SOL_INT_MIN SOL_I32_MIN
+#endif
+
+        /*
+         * SOL_INT_MAX - maximum value of sol_int
+         */
+#if (sol_env_wordsz() == 64)
+#       define SOL_INT_MAX SOL_I64_MAX
+#else
+#       define SOL_INT_MAX SOL_I32_MAX
+#endif
+
+        /*
+         * SOL_INT_FMT - format specifier for sol_int
+         */
+#if (sol_env_wordsz() == 64)
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#               define SOL_INT_FMT PRIdFAST64
+#       else
+#               define SOL_INT_FMT SOL_I64_FMT
+#       endif
+#else
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#               define SOL_INT_FMT PRIdFAST32
+#       else
+#               define SOL_INT_FMT SOL_I32_FMT
+#       endif
+#endif
+
+
+
+
+        /*
+         * sol_u8 - 8-bit unsigned integer
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef uint8_t sol_u8;
+#else
+        typedef unsigned char sol_u8;
+#endif
+
+        /*
+         * SOL_U8_MIN - minimum value of sol_u8
+         */
+#define SOL_U8_MIN ((sol_u8) 0)
+
+        /*
+         * SOL_U8_MAX - maximum value of sol_u8
+         */
+#define SOL_U8_MAX ((sol_u8) 255)
+
+        /*
+         * SOL_U8_FMT - format specifier for sol_u8
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_U8_FMT PRIu32
+#else
+#       define SOL_U8_FMT "u"
+#endif
+
+
+
+
+        /*
+         * sol_u16 - 16-bit signed integer
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef uint16_t sol_u16;
+#else
+        typedef unsigned short int sol_u16;
+#endif
+
+        /*
+         * SOL_U16_MIN - minimum value of sol_u16
+         */
+#define SOL_U16_MIN ((sol_u16) 0)
+
+        /*
+         * SOL_U16_MAX - maximum value of sol_u16
+         */
+#define SOL_U16_MAX ((sol_u16) 65535)
+
+        /*
+         * SOL_U16_FMT - format specifier for sol_u16
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_U16_FMT PRIu32
+#else
+#       define SOL_U16_FMT "u"
+#endif
+
+
+
+
+        /*
+         * sol_u32 - 32-bit unsigned integer
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef uint32_t sol_u32;
+#else
+        typedef unsigned int sol_u32;
+#endif
+
+        /*
+         * SOL_U32_MIN - minimum value of sol_u32
+         */
+#define SOL_U32_MIN ((sol_u32) 0)
+
+        /*
+         * SOL_U32_MAX - maximum value of sol_u32
+         */
+#define SOL_U32_MAX ((sol_u32) 4294967295)
+
+        /*
+         * SOL_U32_FMT - format specifier for sol_u32
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_U32_FMT PRIu32
+#else
+#       define SOL_U32_FMT "u"
+#endif
+
+
+
+
+        /*
+         * sol_u64 - 64-bit unsigned integer
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+        typedef uint64_t sol_u64;
+#elif (sol_env_wordsz() == 64)
+        typedef signed long sol_u64;
+#else
+#       error sol_u64: 64-bit types not supported in current environment
+#endif
+
+        /*
+         * SOL_U64_MIN - minimum value of sol_u64
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99 || sol_env_wordsz() == 64)
+#       define SOL_U64_MIN ((sol_u64) 0)
+#else
+#       error SOL_U64_MIN: 64-bit types not supported in current environment
+#endif
+
+        /*
+         * SOL_U64_MAX - maximum value of sol_u64
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99 || sol_env_wordsz() == 64)
+#       define SOL_U64_MAX ((sol_u64) 18446744073709551615)
+#else
+#       error SOL_U64_MAX: 64-bit types not supported in current environment
+#endif
+
+        /*
+         * SOL_U64_FMT - format specifier for sol_u64
+         */
+#if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#       define SOL_U64_FMT PRIu64
+#elif (sol_env_wordsz() == 64)
+#       define SOL_U64_FMT "lu"
+#else
+#       error SOL_U64_FMT: 64-bit types not supported in current environment
+#endif
+
+
+
+
+        /*
+         * sol_uint - native size unsigned integer
+         */
+#if (sol_env_wordsz() == 64)
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+                typedef uint_fast64_t sol_uint;
+#       else
+                typedef sol_u64 sol_uint;
+#       endif
+#else
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+                typedef uint_fast32_t sol_uint;
+#       else
+                typedef sol_u32 sol_uint;
+#       endif
+#endif
+
+        /*
+         * SOL_UINT_MIN - minimum value of sol_uint
+         */
+#define SOL_UINT_MIN ((sol_uint) 0x0)
+
+        /*
+         * SOL_UINT_MAX - maximum value of sol_uint
+         */
+#if (sol_env_wordsz() == 64)
+#       define SOL_UINT_MAX SOL_U64_MAX
+#else
+#       define SOL_UINT_MAX SOL_U32_MAX
+#endif
+
+        /*
+         * SOL_UINT_FMT - format specifier for sol_uint
+         */
+#if (sol_env_wordsz() == 64)
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#               define SOL_UINT_FMT PRIuFAST64
+#       else
+#               define SOL_UINT_FMT SOL_U64_FMT
+#       endif
+#else
+#       if (sol_env_stdc() >= SOL_ENV_STDC_C99)
+#               define SOL_UINT_FMT PRIuFAST32
+#       else
+#               define SOL_UINT_FMT SOL_U32_FMT
+#       endif
+#endif
+
+
+
+
+        /*
+         * sol_f64 - 64-bit floating point number
+         */
+typedef double sol_f64;
+
+        /*
+         * SOL_F64_MIN - minimum value of sol_f64
+         */
+#define SOL_F64_MIN ((sol_f64) -1e+37)
+
+        /*
+         * SOL_F64_MAX - maximum value of sol_f64
+         */
+#define SOL_F64_MAX ((sol_f64) 1e+37)
+
+        /*
+         * SOL_F64_FMT - format specifier for sol_f64
+         */
+#define SOL_F64_FMT "f"
+
+#define SOL_F64_EPSILON DBL_EPSILON
+
+        /*
+         * sol_f64_lt() - compares two sol_f64 for less than
+         */
+extern SOL_BOOL sol_f64_lt(const sol_f64 lhs, const sol_f64 rhs);
+
+        /*
+         * sol_f64_eq() - compares two sol_f64 for equality
+         */
+extern SOL_BOOL sol_f64_eq(const sol_f64 lhs, const sol_f64 rhs);
+
+        /*
+         * sol_f64_gt() - compares two sol_f64 for greater than
+         */
+extern SOL_BOOL sol_f64_gt(const sol_f64 lhs, const sol_f64 rhs);
+
+
+
+
+        /*
+         * sol_f32 - 32-bit floating point number
+         */
+typedef float sol_f32;
+
+        /*
+         * SOL_F32_MIN - minimum value of sol_f32
+         */
+#define SOL_F32_MIN ((sol_f32) -1e+37)
+
+        /*
+         * SOL_F32_MAX - maximum value of sol_f32
+         */
+#define SOL_F32_MAX ((sol_f32) 1e+37)
+
+        /*
+         * SOL_F32_FMT - format specifier for sol_f32
+         */
+#define SOL_F32_FMT "f"
+
+#define SOL_F32_EPSILON FLT_EPSILON
+
+#define sol_f32_lt(lhs, rhs) \
+        sol_f64_lt((lhs), (rhs))
+
+#define sol_f32_eq(lhs, rhs) \
+        sol_f64_eq((lhs), (rhs))
+
+#define sol_f32_gt(lhs, rhs) \
+        sol_f64_gt((lhs), (rhs))
+
+
+
+
+        /*
+         * sol_float - native size floating point number
+         */
+#if (sol_env_wordsz() == 64)
+        typedef double sol_float;
+#else
+        typedef float sol_float;
+#endif
+
+        /*
+         * SOL_FLOAT_MIN - minimum value of sol_float
+         */
+#define SOL_FLOAT_MIN ((sol_float) -1e+37)
+
+        /*
+         * SOL_FLOAT_MAX - maximum value of sol_float
+         */
+#define SOL_FLOAT_MAX ((sol_float) 1e+37)
+
+        /*
+         * SOL_FLOAT_FMT - format specifier for sol_f64
+         */
+#define SOL_FLOAT_FMT "f"
+
+#if (sol_env_wordsz() == 64)
+#       define SOL_FLOAT_EPSILON SOL_F64_EPSILON
+#else
+#       define SOL_FLOAT_EPSILON SOL_F32_EPSILON
+#endif
+
+#define sol_float_lt(lhs, rhs) \
+        sol_f64_lt((lhs), (rhs))
+
+#define sol_float_eq(lhs, rhs) \
+        sol_f64_eq((lhs), (rhs))
+
+#define sol_float_gt(lhs, rhs) \
+        sol_f64_gt((lhs), (rhs))
+
+
+
+
+#endif /* (!defined __SOL_PRIMITIVES_MODULE) */
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/inc/ptr.h
+++ b/inc/ptr.h
@@ -34,8 +34,8 @@
 
 
         /* include required header files */
-#include "./error.h"
-#include <stddef.h>
+#include "error.h"
+#include "prim.h"
 
 
 
@@ -94,7 +94,7 @@ typedef void sol_ptr;
  *        - SOL_ERNO_HEAP if heap memory failure occurs
  */
 extern sol_erno sol_ptr_new(sol_ptr **ptr,
-                            const size_t sz); /* NOLINT */
+                            sol_size sz);
 
 
 
@@ -129,7 +129,7 @@ extern sol_erno sol_ptr_new(sol_ptr **ptr,
  */
 extern sol_erno sol_ptr_copy(sol_ptr **ptr,
                              const sol_ptr *src,
-                             const size_t len); /* NOLINT */
+                             sol_size len);
 
 
 

--- a/inc/test.h
+++ b/inc/test.h
@@ -32,6 +32,7 @@
 
 
 
+#include "./prim.h"
 #include "./error.h"
 
 
@@ -111,11 +112,11 @@ typedef void (sol_tlog)(const char *desc,
  *      Although the sol_tsuite type is defined as a transparent type so that it
  *      has no dependence on heap memory interfaces (which may not be available
  *      in freestanding environments), it should be treated as an opaque type,
- *      and unsed only through its interface functions declared below.
+ *      and used only through its interface functions declared below.
  */
 typedef struct __sol_tsuite {
-        int total;
-        int fail;
+        sol_uint total;
+        sol_uint fail;
         char desc[SOL_TSUITE_MAXTCASE][SOL_TCASE_MAXDESCLEN];
         sol_tcase *tcase[SOL_TSUITE_MAXTCASE];
         sol_tlog *tlog;
@@ -236,7 +237,7 @@ extern sol_erno sol_tsuite_register(sol_tsuite *tsuite,
  *        - SOL_ERNO_PTR if an invalid pointer is passed as an argument
  */
 extern sol_erno sol_tsuite_pass(const sol_tsuite *tsuite,
-                                int *pass);
+                                sol_uint *pass);
 
 
 
@@ -258,7 +259,7 @@ extern sol_erno sol_tsuite_pass(const sol_tsuite *tsuite,
  *        - SOL_ERNO_PTR if an invalid pointer is passed as an argument
  */
 extern sol_erno sol_tsuite_fail(const sol_tsuite *tsuite,
-                                int *fail);
+                                sol_uint *fail);
 
 
 
@@ -279,7 +280,7 @@ extern sol_erno sol_tsuite_fail(const sol_tsuite *tsuite,
  *        - SOL_ERNO_PTR if an invalid pointer is passed as an argument
  */
 extern sol_erno sol_tsuite_total(const sol_tsuite *tsuite,
-                                 int *total);
+                                 sol_uint *total);
 
 
 

--- a/src/error.c
+++ b/src/error.c
@@ -27,6 +27,7 @@
 
 
         /* include required header files */
+#include "../inc/prim.h"
 #include "../inc/error.h"
 
 
@@ -35,7 +36,7 @@
 /*
  *      BFR_LEN - length of string buffer
  */
-#define BFR_LEN 19
+#define BFR_LEN (19)
 
 
 
@@ -54,7 +55,7 @@ static sol_tls char bfr_hnd[BFR_LEN];
 extern const char *sol_erno_str(sol_erno erno)
 {
         const int RADIX = 16;
-        register int i = 0;
+        register sol_index i = 0;
 
                 /* prefix with '0x' to indicate hex code */
         bfr_hnd[i] = '0';

--- a/src/prim.c
+++ b/src/prim.c
@@ -1,0 +1,44 @@
+
+        /* include required header files */
+#include "../inc/prim.h"
+#include "../inc/libc.h"
+
+
+
+
+        /* define the float_lt() utility function; this function returns true if
+         * @lhs < @rhs, and false otherwise; this function uses Donald Knuth's
+         * algorithm for the same as answered by user mch in the question posted
+         * on https://stackoverflow.com/questions/17333 */
+extern SOL_BOOL sol_f64_lt(const sol_f64 lhs, const sol_f64 rhs)
+{
+        return (rhs - lhs) > SOL_F64_EPSILON;
+}
+
+
+
+
+        /* define the float_eq() utility function; this function returns true if
+         * @lhs == @rhs, and false otherwise; this function uses Donald Knuth's
+         * algorithm for the same as answered by user mch in the question posted
+         * on https://stackoverflow.com/questions/17333 */
+extern SOL_BOOL sol_f64_eq(const sol_f64 lhs, const sol_f64 rhs)
+{
+        return fabs(lhs - rhs) < SOL_F64_EPSILON;
+}
+
+
+
+
+        /* define the float_gt() utility function; this function returns true if
+         * @lhs > @rhs, and false otherwise; this function uses Donald Knuth's
+         * algorithm for the same as answered by user mch in the question posted
+         * on https://stackoverflow.com/questions/17333 */
+extern SOL_BOOL sol_f64_gt(const sol_f64 lhs, const sol_f64 rhs)
+{
+        return (lhs - rhs) > SOL_F64_EPSILON;
+}
+
+
+
+

--- a/src/ptr.c
+++ b/src/ptr.c
@@ -43,13 +43,13 @@
  */
 static sol_inline void copy_byte(sol_ptr **ptr,
                                  const sol_ptr *src,
-                                 const size_t len)
+                                 sol_size len)
 {
                 /* @ptr, @src and @len are valid, as they have already been
                  * checked by the calling function sol_ptr_copy() */
-        register char *bdst = (char*) *ptr;
-        register char *bsrc = (char*) src;
-        register size_t itr = len;
+        register sol_w8 *bdst = (sol_w8*) *ptr;
+        register sol_w8 *bsrc = (sol_w8*) src;
+        register sol_size itr = len;
 
                 /* copy @src to @ptr byte-by-byte for @len bytes */
         for (; itr; itr--, *bdst++ = *bsrc++); /* NOLINT */
@@ -62,7 +62,7 @@ static sol_inline void copy_byte(sol_ptr **ptr,
  *      sol_ptr_new() - declared in sol/inc/ptr.h
  */
 extern sol_erno sol_ptr_new(sol_ptr **ptr,
-                            const size_t sz)
+                            sol_size sz)
 {
 SOL_TRY:
                 /* check preconditions */
@@ -89,7 +89,7 @@ SOL_FINALLY:
  */
 extern sol_erno sol_ptr_copy(sol_ptr **ptr,
                              const sol_ptr *src,
-                             const size_t len)
+                             sol_size len)
 {
 SOL_TRY:
                 /* check preconditions */

--- a/src/test.c
+++ b/src/test.c
@@ -41,7 +41,7 @@
 static void tsuite_init(sol_tsuite *tsuite,
                         sol_tlog *tlog)
 {
-        register int i;
+        register sol_index i;
 
                 /* initialise counters and logging callback */
         tsuite->total = 0;
@@ -50,8 +50,8 @@ static void tsuite_init(sol_tsuite *tsuite,
 
                 /* initialise test case callback and description arrays */
         for (i = 0; i < SOL_TSUITE_MAXTCASE; i++) {
-                *tsuite->desc [i] = '\0';
-                tsuite->tcase [i] = 0;
+                *tsuite->desc[i] = '\0';
+                tsuite->tcase[i] = 0;
         }
 }
 
@@ -95,7 +95,7 @@ SOL_TRY:
 
                 /* initialise member fields, setting the logging callback to
                  * @tlog */
-        tsuite_init (tsuite, tlog);
+        tsuite_init(tsuite, tlog);
 
 SOL_CATCH:
                 /* log current error code */
@@ -132,7 +132,7 @@ extern sol_erno sol_tsuite_register(sol_tsuite *tsuite,
                                     sol_tcase *tcase,
                                     const char *desc)
 {
-        register int len;
+        register sol_index len;
         register char *itr;
 
 SOL_TRY:
@@ -175,7 +175,7 @@ SOL_FINALLY:
  *      sol_tsuite_pass() - declared in sol/inc/test.h
  */
 extern sol_erno sol_tsuite_pass(const sol_tsuite *tsuite,
-                                int *pass)
+                                sol_uint *pass)
 {
 SOL_TRY:
                 /* check preconditions */
@@ -200,7 +200,7 @@ SOL_FINALLY:
  *      sol_tsuite_fail() - declared in sol/inc/test.h
  */
 extern sol_erno sol_tsuite_fail(const sol_tsuite *tsuite,
-                                int *fail)
+                                sol_uint *fail)
 {
 SOL_TRY:
                 /* check preconditions */
@@ -225,7 +225,7 @@ SOL_FINALLY:
  *      sol_tsuite_total() - declared in sol/inc/test.h
  */
 extern sol_erno sol_tsuite_total(const sol_tsuite *tsuite,
-                                 int *total)
+                                 sol_uint *total)
 {
 SOL_TRY:
                 /* check preconditions */
@@ -251,8 +251,8 @@ SOL_FINALLY:
  */
 extern sol_erno sol_tsuite_exec(sol_tsuite *tsuite)
 {
-        register int      i;
-        auto     sol_erno erno;
+        register sol_index i;
+        auto sol_erno erno;
 
 SOL_TRY:
                 /* check preconditions */

--- a/test/runner.c
+++ b/test/runner.c
@@ -26,7 +26,7 @@
 
 
 
-#include "./suite.h"
+#include "suite.h"
 #include <stdio.h>
 
 
@@ -45,9 +45,9 @@
  *        - SOL_ERNO_PTR if an invalid pointer has been referenced
  */
 typedef sol_erno (suite)(sol_tlog *log,
-                         int *pass,
-                         int *fail,
-                         int *total);
+                         sol_uint *pass,
+                         sol_uint *fail,
+                         sol_uint *total);
 
 
 
@@ -71,6 +71,7 @@ typedef enum {
         SUITE_PTR,
         SUITE_PTR2,
         SUITE_LOG,
+        SUITE_PRIM,
         SUITE_COUNT
 } SUITE;
 
@@ -88,7 +89,7 @@ typedef enum {
 /*
  *      LOG_SIGMAMSG - log message for sigma test counters
  */
-#define LOG_SIGMAMSG "\n%d test(s) run, %d passed, %d failed\n"
+#define LOG_SIGMAMSG "\n%lu test(s) run, %lu passed, %lu failed\n"
 
 
 
@@ -124,9 +125,9 @@ static suite *suite_hnd[SUITE_COUNT];
  *        - total: total test cases per suite
  */
 static struct {
-        int pass[SUITE_COUNT];
-        int fail[SUITE_COUNT];
-        int total[SUITE_COUNT];
+        sol_uint pass[SUITE_COUNT];
+        sol_uint fail[SUITE_COUNT];
+        sol_uint total[SUITE_COUNT];
 } stat_suite;
 
 
@@ -139,9 +140,9 @@ static struct {
  *        - total: sigma of total test cases
  */
 static struct {
-        int pass;
-        int fail;
-        int total;
+        sol_uint pass;
+        sol_uint fail;
+        sol_uint total;
 } stat_sigma;
 
 
@@ -208,25 +209,22 @@ log_tcase(char     const *desc, /* test case description            */
 /*
  *      log_sigma() - prints and logs sigma statistics
  */
-static void
-log_sigma(void)
+static void log_sigma(void)
 {
 
                 /* print sigma statistics */
-        printf (LOG_SIGMAMSG,
-                stat_sigma.total,
-                stat_sigma.pass,
-                stat_sigma.fail
-               );
+        printf(LOG_SIGMAMSG,
+               stat_sigma.total,
+               stat_sigma.pass,
+               stat_sigma.fail);
 
                 /* log sigma statistics */
         if (log_hnd) {
-                fprintf (log_hnd,
-                         LOG_SIGMAMSG,
-                         stat_sigma.total,
-                         stat_sigma.pass,
-                         stat_sigma.fail
-                        );
+                fprintf(log_hnd,
+                        LOG_SIGMAMSG,
+                        stat_sigma.total,
+                        stat_sigma.pass,
+                        stat_sigma.fail);
         }
 }
 
@@ -236,16 +234,15 @@ log_sigma(void)
 /*
  *      stat_init() - initialise test statistics
  */
-static void
-stat_init(void)
+static void stat_init(void)
 {
-        register int i; /* iterator */
+        register sol_index i; /* iterator */
 
                 /* initialise test suite statistics */
         for (i = 0; i < SUITE_COUNT; i++) {
-                stat_suite.pass  [i] = 0;
-                stat_suite.fail  [i] = 0;
-                stat_suite.total [i] = 0;
+                stat_suite.pass[i] = 0;
+                stat_suite.fail[i] = 0;
+                stat_suite.total[i] = 0;
         }
 
                 /* initialise sigma statistics */
@@ -260,10 +257,9 @@ stat_init(void)
 /*
  *      stat_sum() - calculates sigma statistics
  */
-static void
-stat_sum(void)
+static void stat_sum(void)
 {
-        register int i; /* iterator */
+        register sol_index i; /* iterator */
 
                 /* sum test suite statistics */
         for (i = 0; i < SUITE_COUNT; i++) {
@@ -289,6 +285,7 @@ static void suite_init(void)
         suite_hnd[SUITE_PTR] = __sol_tests_ptr;
         suite_hnd[SUITE_PTR2] = __sol_tests_ptr2;
         suite_hnd[SUITE_LOG] = __sol_tests_log;
+        suite_hnd[SUITE_PRIM] = __sol_tests_prim;
 }
 
 
@@ -297,18 +294,16 @@ static void suite_init(void)
 /*
  *      suite_exec() - executes test suites
  */
-static void
-suite_exec(void)
+static void suite_exec(void)
 {
-        register int i; /* iterator */
+        register sol_index i; /* iterator */
 
                 /* execute test suites */
         for (i = 0; i < SUITE_COUNT; i++) {
-                suite_hnd [i] (log_tcase,
-                               stat_suite.pass  + i,
-                               stat_suite.fail  + i,
-                               stat_suite.total + i
-                              );
+                suite_hnd[i](log_tcase,
+                              stat_suite.pass  + i,
+                              stat_suite.fail  + i,
+                              stat_suite.total + i);
         }
 }
 
@@ -318,8 +313,7 @@ suite_exec(void)
 /*
  *      main() - main entry point of test runner
  */
-int main(int argc,
-         char **argv)
+int main(int argc, char **argv)
 {
                 /* initialise */
         log_init(argc, argv);

--- a/test/suite.h
+++ b/test/suite.h
@@ -39,69 +39,69 @@
 
 
 
-/*
- *      __sol_tsuite_error() - test suite for exception handling module
- */
+        /*
+         * __sol_tsuite_error() - test suite for exception handling module
+         */
 extern sol_erno __sol_tsuite_error(sol_tlog *log,
-                                   int *pass,
-                                   int *fail,
-                                   int *total);
+                                   sol_uint *pass,
+                                   sol_uint *fail,
+                                   sol_uint *total);
 
 
 
 
-/*
- *      __sol_tsuite_test() - test suite for unit testing module
- */
+        /*
+         * __sol_tsuite_test() - test suite for unit testing module
+         */
 extern sol_erno __sol_tsuite_test(sol_tlog *log,
-                                  int *pass,
-                                  int *fail,
-                                  int *total);
+                                  sol_uint *pass,
+                                  sol_uint *fail,
+                                  sol_uint *total);
 
 
 
 
-/*
- *      __sol_tsuite_hint() - test suite for compiler hints module
- */
+        /*
+         * __sol_tsuite_hint() - test suite for compiler hints module
+         */
 extern sol_erno __sol_tsuite_hint(sol_tlog *log,
-                                  int *pass,
-                                  int *fail,
-                                  int *total);
+                                  sol_uint *pass,
+                                  sol_uint *fail,
+                                  sol_uint *total);
 
 
 
 
-/*
- *      __sol_tests_env() - test suite for environment module
- */
+        /*
+         * __sol_tests_env() - test suite for environment module
+         */
 extern sol_erno __sol_tests_env(sol_tlog *log,
-                                int *pass,
-                                int *fail,
-                                int *total);
+                                sol_uint *pass,
+                                sol_uint *fail,
+                                sol_uint *total);
 
 
 
 
-/*
- *      __sol_tests_ptr() - test suite for the pointer module
- */
+        /*
+         * __sol_tests_ptr() - test suite for the pointer module
+         */
 extern sol_erno __sol_tests_ptr(sol_tlog *log,
-                                int *pass,
-                                int *fail,
-                                int *total);
+                                sol_uint *pass,
+                                sol_uint *fail,
+                                sol_uint *total);
 
 
 
 
-/*
- *      __sol_tests_ptr2() - mock freestanding tests for the pointer module
- */
+        /*
+         * __sol_tests_ptr2() - mock freestanding tests for the pointer module
+         */
 #if (SOL_ENV_HOSTED_NONE != sol_env_host())
         extern sol_erno __sol_tests_ptr2(sol_tlog *log,
-                                         int      *pass,
-                                         int      *fail,
-                                         int      *total);
+                                         sol_uint *pass,
+                                         sol_uint *fail,
+                                         sol_uint *total);
 #else
 #       define __sol_tests_ptr2()
 #endif
@@ -109,13 +109,24 @@ extern sol_erno __sol_tests_ptr(sol_tlog *log,
 
 
 
-/*
- *      __sol_tests_log() - test suite for the logging module
- */
+        /*
+         * __sol_tests_log() - test suite for the logging module
+         */
 extern sol_erno __sol_tests_log(sol_tlog *log,
-                                int *pass,
-                                int *fail,
-                                int *total);
+                                sol_uint *pass,
+                                sol_uint *fail,
+                                sol_uint *total);
+
+
+
+
+        /*
+         * __sol_tests_prim() - test suite for the primitives module
+         */
+extern sol_erno __sol_tests_prim(sol_tlog *log,
+                                 sol_uint *pass,
+                                 sol_uint *fail,
+                                 sol_uint *total);
 
 
 

--- a/test/ts-env.c
+++ b/test/ts-env.c
@@ -171,9 +171,9 @@ SOL_FINALLY:
  *      __sol_tests_env() - declared in sol/test/suite.h
  */
 extern sol_erno __sol_tests_env(sol_tlog *log,
-                                int *pass,
-                                int *fail,
-                                int *total)
+                                sol_uint *pass,
+                                sol_uint *fail,
+                                sol_uint *total)
 {
         auto sol_tsuite __ts, *ts = &__ts;
 

--- a/test/ts-error.c
+++ b/test/ts-error.c
@@ -212,9 +212,9 @@ SOL_FINALLY:
  *      __sol_tsuite_error() - declared in sol/test/suite.h
  */
 extern sol_erno __sol_tsuite_error(sol_tlog *log,
-                                   int *pass,
-                                   int *fail,
-                                   int *total)
+                                   sol_uint *pass,
+                                   sol_uint *fail,
+                                   sol_uint *total)
 {
         auto sol_tsuite __ts, *ts = &__ts;
 

--- a/test/ts-hint.c
+++ b/test/ts-hint.c
@@ -93,7 +93,7 @@ static void clang_on(void)
 /*
  *      mock_hot() - mocks definition of hot function
  */
-static sol_hot int mock_hot(void)
+static sol_hot sol_int mock_hot(void)
 {
         return 1;
 }
@@ -104,7 +104,7 @@ static sol_hot int mock_hot(void)
 /*
  *      mock_cold() - mocks definition of cold function
  */
-static sol_cold int mock_cold(void)
+static sol_cold sol_int mock_cold(void)
 {
         return 1;
 }
@@ -115,7 +115,7 @@ static sol_cold int mock_cold(void)
 /*
  *      mock_inline() - mocks definition of inline function
  */
-static sol_inline int mock_inline(void)
+static sol_inline sol_int mock_inline(void)
 {
         return 1;
 }
@@ -126,7 +126,7 @@ static sol_inline int mock_inline(void)
 /*
  *      mock_restrict() - mocks use of restrict pointer
  */
-static int mock_restrict(int *sol_restrict ptr)
+static int mock_restrict(sol_int *sol_restrict ptr)
 {
         *ptr = 1;
         return *ptr;
@@ -493,7 +493,7 @@ SOL_FINALLY:
 static sol_erno restrict_01(void)
 {
         #define RESTRICT_01 "A pointer marked restricted behaves as expected"
-        auto int tmp = 0;
+        auto sol_int tmp = 0;
 
 SOL_TRY:
                 /* check test condition */
@@ -512,9 +512,9 @@ SOL_FINALLY:
  *      __sol_hint_test() - declared in sol/test/suite.h
  */
 extern sol_erno __sol_tsuite_hint(sol_tlog *log,
-                                  int *pass,
-                                  int *fail,
-                                  int *total)
+                                  sol_uint *pass,
+                                  sol_uint *fail,
+                                  sol_uint *total)
 {
         auto sol_tsuite __ts, *ts = &__ts;
 

--- a/test/ts-log.c
+++ b/test/ts-log.c
@@ -969,9 +969,9 @@ static sol_erno erno_test2(void)
  *      __sol_tests_log() - declared in sol/test/suite.h
  */
 extern sol_erno __sol_tests_log(sol_tlog *log,
-                                int *pass,
-                                int *fail,
-                                int *total)
+                                sol_uint *pass,
+                                sol_uint *fail,
+                                sol_uint *total)
 {
         auto sol_tsuite __ts, *ts = &__ts;
 

--- a/test/ts-prim.c
+++ b/test/ts-prim.c
@@ -1,0 +1,609 @@
+/******************************************************************************
+ *                           SOL LIBRARY v1.0.0+41
+ *
+ * File: sol/test/ts-prim.c
+ *
+ * Description:
+ *      This file is part of the internal quality checking of the Sol Library.
+ *      It implements the test suite for the primitives module.
+ *
+ * Authors:
+ *      Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * Copyright:
+ *      (c) 2019 Abhishek Chakravarti
+ *      <abhishek@taranjali.org>
+ *
+ * License:
+ *      Released under the GNU General Public License version 3 (GPLv3)
+ *      <http://opensource.org/licenses/GPL-3.0>. See the accompanying LICENSE
+ *      file for complete licensing details.
+ *
+ *      BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT
+ *      YOU HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+
+
+        /* include required header files */
+#include "../inc/prim.h"
+#include "suite.h"
+
+
+
+
+        /* bool_test1() implements the unit test described by BOOL_TEST1 */
+static sol_erno bool_test1(void)
+{
+        #define BOOL_TEST1 "SOL_BOOL_TRUE must evaluate to 1"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (SOL_BOOL_TRUE == 1, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* bool_test2() implements the unit test described by BOOL_TEST2 */
+static sol_erno bool_test2(void)
+{
+        #define BOOL_TEST2 "SOL_BOOL_FALSE must evaluate to 0"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (SOL_BOOL_FALSE == 0, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* w8_test1() implements the unit test described by W8_TEST1 */
+static sol_erno w8_test1(void)
+{
+        #define W8_TEST1 "size of sol_w8 is at least 8 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_w8) >= 1, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* w16_test1() implements the unit test described by W16_TEST1 */
+static sol_erno w16_test1(void)
+{
+        #define W16_TEST1 "size of sol_w16 is at least 16 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_w16) >= 2, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* w32_test1() implements the unit test described by W32_TEST1 */
+static sol_erno w32_test1(void)
+{
+        #define W32_TEST1 "size of sol_w32 is at least 32 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_w32) >= 4, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* w64_test1() implements the unit test described by W64_TEST1 */
+static sol_erno w64_test1(void)
+{
+        #define W64_TEST1 "size of sol_w64 is at least 64 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_w64) >= 8, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* i8_test1() implements the unit test described by I8_TEST1 */
+static sol_erno i8_test1(void)
+{
+        #define I8_TEST1 "size of sol_i8 is at least 8 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_i8) >= 1, SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* i16_test1() implements the unit test described by I16_TEST1 */
+static sol_erno i16_test1(void)
+{
+        #define I16_TEST1 "size of sol_i16 is at least 16 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_i16) >= 2, SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* i32_test1() implements the unit test described by I32_TEST1 */
+static sol_erno i32_test1(void)
+{
+        #define I32_TEST1 "size of sol_i32 is at least 32 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_i32) >= 4, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* i64_test1() implements the unit test described by I64_TEST1 */
+static sol_erno i64_test1(void)
+{
+        #define I64_TEST1 "size of sol_i64 is at least 64 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_i64) >= 8, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* u8_test1() implements the unit test described by U8_TEST1 */
+static sol_erno u8_test1(void)
+{
+        #define U8_TEST1 "size of sol_u8 is at least 8 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_u8) >= 1, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* u16_test1() implements the unit test described by U16_TEST1 */
+static sol_erno u16_test1(void)
+{
+        #define U16_TEST1 "size of sol_u16 is at least 16 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_u16) >= 2, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* u32_test1() implements the unit test described by U32_TEST1 */
+static sol_erno u32_test1(void)
+{
+        #define U32_TEST1 "size of sol_u32 is at least 32 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_u32) >= 4, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* u64_test1() implements the unit test described by U64_TEST1 */
+static sol_erno u64_test1(void)
+{
+        #define U64_TEST1 "size of sol_u64 is at least 64 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_u64) >= 8, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* f32_test1() implements the unit test described by F32_TEST1 */
+static sol_erno f32_test1(void)
+{
+        #define F32_TEST1 "size of sol_f32 is at least 32 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_f32) >= 4, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* define the f32_test2() unit test function; this function implements
+         * the test case described by the F32_TEST2 symbolic constant */
+static sol_erno f32_test2(void)
+{
+        #define F32_TEST2 "sol_f32_lt() return true if its lhs is less than" \
+                          " its rhs"
+        const sol_f32 lhs = (sol_f32) 3.141;
+        const sol_f32 rhs = (sol_f32) 3.1415;
+
+
+SOL_TRY:
+        sol_assert (sol_f32_lt(lhs, rhs), SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* f32_test3() implements the test case described by F32_TEST3 */
+static sol_erno f32_test3(void)
+{
+        #define F32_TEST3 "sol_f32_eq() returns true if passed two equal" \
+                          " sol_f32 values"
+        const sol_f32 lhs = (sol_f32) 3.1415;
+
+SOL_TRY:
+        sol_assert (sol_f32_eq(lhs, lhs), SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* f32_test4() implements the test case described by F32_TEST4 */
+static sol_erno f32_test4(void)
+{
+        #define F32_TEST4 "sol_f32_gt() returns true if its lhs parameter is" \
+                          " greater than its rhs parameter"
+        const sol_f32 lhs = 3.1415;
+        const sol_f32 rhs = 3.141;
+
+SOL_TRY:
+        sol_assert (sol_f32_gt(lhs, rhs), SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* f64_test1() implements the unit test described by F64_TEST1 */
+static sol_erno f64_test1(void)
+{
+        #define F64_TEST1 "size of sol_f64 is at least 64 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_f64) >= 8, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* f64_test2() implements the test case described by F64_TEST2 */
+static sol_erno f64_test2(void)
+{
+        #define F64_TEST2 "sol_f64_lt() returns true when its lhs is less" \
+                          " than its rhs"
+        const sol_f32 lhs = (sol_f32) 3.1415926;
+        const sol_f32 rhs = (sol_f32) 3.14159265;
+
+
+SOL_TRY:
+        sol_assert (sol_f64_lt(lhs, rhs), SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* f64_test3() implements the test case described by F64_TEST3 */
+static sol_erno f64_test3(void)
+{
+        #define F64_TEST3 "sol_f64_eq() returns true if passed two equal" \
+                          " sol_f64 values"
+        const sol_f64 lhs = (sol_f64) 3.14159265;
+
+SOL_TRY:
+        sol_assert (sol_f64_eq(lhs, lhs), SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* f64_test4() implements the test case described by F64_TEST4 */
+static sol_erno f64_test4(void)
+{
+        #define F64_TEST4 "sol_f64_gt() return true if its lhs parameter is" \
+                          " greater than its rhs parameter"
+        const sol_f32 lhs = 3.14159265;
+        const sol_f32 rhs = 3.1415926;
+
+SOL_TRY:
+        sol_assert (sol_f64_gt(lhs, rhs), SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* float_test1() implements the unit test described by FLOAT_TEST1 */
+static sol_erno float_test1(void)
+{
+        #define FLOAT_TEST1 "size of sol_float is at least 32 bits"
+
+SOL_TRY:
+                /* check test condition */
+        sol_assert (sizeof (sol_float) >= 4, SOL_ERNO_TEST);
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        return sol_erno_get();
+}
+
+
+
+
+        /* float_test2() implements the test case described bh FLOAT_TEST2 */
+static sol_erno float_test2(void)
+{
+        #define FLOAT_TEST2 "sol_float_lt() return true if its lhs is less" \
+                            " than its rhs"
+        const sol_float lhs = (sol_f32) 3.141;
+        const sol_float rhs = (sol_f32) 3.1415;
+
+
+SOL_TRY:
+        sol_assert (sol_float_lt(lhs, rhs), SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* float_test3() implements the test case described by FLOAT_TEST3 */
+static sol_erno float_test3(void)
+{
+        #define FLOAT_TEST3 "sol_float_eq() returns true if passed two equal" \
+                            " sol_float values"
+        const sol_float lhs = (sol_float) 3.1415;
+
+SOL_TRY:
+        sol_assert (sol_float_eq(lhs, lhs), SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* float_test4() implements the test case described by FLOAT_TEST4 */
+static sol_erno float_test4(void)
+{
+        #define FLOAT_TEST4 "sol_float_gt() returns true if its lhs parameter" \
+                            " is greater than its rhs parameter"
+        const sol_float lhs = 3.1415;
+        const sol_float rhs = 3.141;
+
+SOL_TRY:
+        sol_assert (sol_float_gt(lhs, rhs), SOL_ERNO_TEST);
+
+SOL_CATCH:
+SOL_FINALLY:
+        return sol_erno_get();
+}
+
+
+
+
+        /* __sol_tests_prim() was declared in sol/test/suite.h */
+extern sol_erno __sol_tests_prim(sol_tlog *log,
+                                 sol_uint *pass,
+                                 sol_uint *fail,
+                                 sol_uint *total)
+{
+        auto sol_tsuite __ts, *ts = &__ts;
+
+SOL_TRY:
+                /* check preconditions */
+        sol_assert (log && pass && fail && total, SOL_ERNO_PTR);
+
+                /* initialise test suite */
+        sol_try (sol_tsuite_init2(ts, log));
+
+                /* register test cases */
+        sol_try (sol_tsuite_register(ts, bool_test1, BOOL_TEST1));
+        sol_try (sol_tsuite_register(ts, bool_test2, BOOL_TEST2));
+        sol_try (sol_tsuite_register(ts, w8_test1, W8_TEST1));
+        sol_try (sol_tsuite_register(ts, w16_test1, W16_TEST1));
+        sol_try (sol_tsuite_register(ts, w32_test1, W32_TEST1));
+        sol_try (sol_tsuite_register(ts, w64_test1, W64_TEST1));
+        sol_try (sol_tsuite_register(ts, i8_test1, I8_TEST1));
+        sol_try (sol_tsuite_register(ts, i16_test1, I16_TEST1));
+        sol_try (sol_tsuite_register(ts, i32_test1, I32_TEST1));
+        sol_try (sol_tsuite_register(ts, i64_test1, I64_TEST1));
+        sol_try (sol_tsuite_register(ts, u8_test1, U8_TEST1));
+        sol_try (sol_tsuite_register(ts, u16_test1, U16_TEST1));
+        sol_try (sol_tsuite_register(ts, u32_test1, U32_TEST1));
+        sol_try (sol_tsuite_register(ts, u64_test1, U64_TEST1));
+        sol_try (sol_tsuite_register(ts, f32_test1, F32_TEST1));
+        sol_try (sol_tsuite_register(ts, f32_test2, F32_TEST2));
+        sol_try (sol_tsuite_register(ts, f32_test3, F32_TEST3));
+        sol_try (sol_tsuite_register(ts, f32_test4, F32_TEST4));
+        sol_try (sol_tsuite_register(ts, f64_test1, F64_TEST1));
+        sol_try (sol_tsuite_register(ts, f64_test2, F64_TEST2));
+        sol_try (sol_tsuite_register(ts, f64_test3, F64_TEST3));
+        sol_try (sol_tsuite_register(ts, f64_test4, F64_TEST4));
+        sol_try (sol_tsuite_register(ts, float_test1, FLOAT_TEST1));
+        sol_try (sol_tsuite_register(ts, float_test2, FLOAT_TEST2));
+        sol_try (sol_tsuite_register(ts, float_test3, FLOAT_TEST3));
+        sol_try (sol_tsuite_register(ts, float_test4, FLOAT_TEST4));
+
+                /* execute test cases */
+        sol_try (sol_tsuite_exec(ts));
+
+                /* report test counts */
+        sol_try (sol_tsuite_pass(ts, pass));
+        sol_try (sol_tsuite_fail(ts, fail));
+        sol_try (sol_tsuite_total(ts, total));
+
+SOL_CATCH:
+                /* nothing to do in case of an exception */
+
+SOL_FINALLY:
+                /* wind up */
+        sol_tsuite_term(ts);
+        return sol_erno_get();
+}
+
+
+
+
+/******************************************************************************
+ *                                    EOF
+ *          Built on hyperion [Tue Jan 29 02:37:24 UTC 2019]
+ ******************************************************************************/
+

--- a/test/ts-ptr.c
+++ b/test/ts-ptr.c
@@ -336,9 +336,9 @@ SOL_FINALLY:
  *      __sol_tests_ptr() - declared in sol/test/suite.h
  */
 extern sol_erno __sol_tests_ptr(sol_tlog *log,
-                                int *pass,
-                                int *fail,
-                                int *total)
+                                sol_uint *pass,
+                                sol_uint *fail,
+                                sol_uint *total)
 {
         auto sol_tsuite __ts, *ts = &__ts;
 

--- a/test/ts-ptr2.c
+++ b/test/ts-ptr2.c
@@ -54,9 +54,9 @@
  *      __sol_tests_ptr2() - declared in sol/test/suite.h
  */
 extern sol_erno __sol_tests_ptr2(sol_tlog *log,
-                                 int *pass,
-                                 int *fail,
-                                 int *total)
+                                 sol_uint *pass,
+                                 sol_uint *fail,
+                                 sol_uint *total)
 {
 SOL_TRY:
                 /* run pointer module test cases in the simulated freestanding

--- a/test/ts-test.c
+++ b/test/ts-test.c
@@ -309,7 +309,7 @@ static sol_erno test_register5(void)
                            " file. This description in itself is greater than"
                            " the length limited by the SOL_TCASE_MAXDESCLEN"
                            " symbolic constant";
-        register size_t len = 0;
+        register sol_size len = 0;
         auto sol_tsuite __ts, *ts = &__ts;
 
 SOL_TRY:
@@ -339,7 +339,7 @@ static sol_erno test_pass1(void)
         #define DESC_PASS1 "sol_tsuite_pass() throws SOL_ERNO_PTR when passed" \
                            " a null pointer for @tsuite"
         auto sol_tsuite ts;
-        auto int pass;
+        auto sol_uint pass;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -397,7 +397,7 @@ static sol_erno test_pass3(void)
                            " passed test cases if @tsuite has been "       \
                            " initialised by sol_tsuite_init()"
         auto sol_tsuite __ts, *ts = &__ts;
-        auto int pass;
+        auto sol_uint pass;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -426,7 +426,7 @@ static sol_erno test_pass4(void)
                            " passed test cases if @tsuite has been"        \
                            " initialised by sol_tsuite_init2()"
         auto sol_tsuite __ts, *ts = &__ts;
-        auto int pass;
+        auto sol_uint pass;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -454,7 +454,7 @@ static sol_erno test_pass5(void)
         #define DESC_PASS5 "sol_tsuite_pass() reports the correct number of" \
                            " passed test cases"
         auto sol_tsuite __ts, *ts = &__ts;
-        auto int pass;
+        auto sol_uint pass;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -485,7 +485,7 @@ static sol_erno test_fail1(void)
         #define DESC_FAIL1 "sol_tsuite_fail() throws SOL_ERNO_PTR when passed" \
                            " a null pointer for @tsuite"
         auto sol_tsuite ts;
-        auto int fail;
+        auto sol_uint fail;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -543,7 +543,7 @@ static sol_erno test_fail3(void)
                            " failed test cases if @tsuite has been"        \
                            " initialised by sol_tsuite_init()"
         auto sol_tsuite __ts, *ts = &__ts;
-        auto int fail;
+        auto sol_uint fail;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -572,7 +572,7 @@ static sol_erno test_fail4(void)
                            " failed test cases if @tsuite has been"        \
                            " initialised by sol_tsuite_init2()"
         auto sol_tsuite __ts, *ts = &__ts;
-        auto int fail;
+        auto sol_uint fail;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -600,7 +600,7 @@ static sol_erno test_fail5(void)
         #define DESC_FAIL5 "sol_tsuite_fail() reports the correct number of" \
                            " failed test cases"
         auto sol_tsuite __ts, *ts = &__ts;
-        auto int fail;
+        auto sol_uint fail;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -631,7 +631,7 @@ static sol_erno test_total1(void)
         #define DESC_TOTAL1 "sol_tsuite_total() throws SOL_ERNO_PTR when" \
                             " passed a null pointer for @tsuite"
         auto sol_tsuite ts;
-        auto int total;
+        auto sol_uint total;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -689,7 +689,7 @@ static sol_erno test_total3(void)
                             " total test cases if @tsuite has been"          \
                             " initialised by sol_tsuite_init()"
         auto sol_tsuite __ts, *ts = &__ts;
-        auto int total;
+        auto sol_uint total;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -718,7 +718,7 @@ static sol_erno test_total4(void)
                             " total test cases if @tsuite has been"         \
                             " initialised by sol_tsuite_init2()"
         auto sol_tsuite __ts, *ts = &__ts;
-        auto int total;
+        auto sol_uint total;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -746,7 +746,7 @@ static sol_erno test_total5(void)
         #define DESC_TOTAL5 "sol_tsuite_total() reports the correct number of" \
                             " total test cases"
         auto sol_tsuite __ts, *ts = &__ts;
-        auto int total;
+        auto sol_uint total;
 
 SOL_TRY:
                 /* set up test scenario */
@@ -831,9 +831,9 @@ SOL_FINALLY:
  *      __sol_tsuite_test() - declared in sol/test/suite.h
  */
 extern sol_erno __sol_tsuite_test(sol_tlog *log,
-                                  int *pass,
-                                  int *fail,
-                                  int *total)
+                                  sol_uint *pass,
+                                  sol_uint *fail,
+                                  sol_uint *total)
 {
         auto sol_tsuite __ts, *ts = &__ts;
 


### PR DESCRIPTION
The primitives module has now been implemented, barring the sol_char and
sol_string types. The rationale behind this is that the string type
should have its own module as it is fairly extensive.

The following types have been defined:
  * SOL_BOOL
  * sol_w8
  * sol_w16
  * sol_w32
  * sol_w64
  * sol_word
  * sol_size
  * sol_index
  * sol_i8
  * sol_i16
  * sol_i32
  * sol_i64
  * sol_int
  * sol_u8
  * sol_u16
  * sol_u32
  * sol_u64
  * sol_uint
  * sol_f32
  * sol_f64
  * sol_float

Along with these types, their appropriate constants have also been
defined. Additionally, the floating point types have been supplied with
comparator functions that can be used to safely compare two floating
point types.

Some refactoring of the existing code has also been done, especially for
the environment module interface. I'm experimenting with what I think is
a cleaner interface that doesn't sacrifice on documentation.

This pull request closes #46.